### PR TITLE
[FEAT] 테스트 커버리지를 위한 Jacoco 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ subprojects {
 	apply plugin: 'java'
 	apply plugin: 'org.springframework.boot'
 	apply plugin: 'io.spring.dependency-management'
+	apply plugin: 'jacoco'
 
 	sourceCompatibility = '1.8'
 
@@ -33,8 +34,22 @@ subprojects {
 		}
 	}
 
+	jacoco {
+		toolVersion = '0.8.5'
+	}
+
+	jacocoTestReport {
+		reports {
+			html.enabled true
+			xml.enabled false
+			csv.enabled true
+		}
+		finalizedBy 'jacocoTestCoverageVerification'
+	}
+
 	test {
 		useJUnitPlatform()
+		finalizedBy 'jacocoTestReport'
 	}
 
 	configurations {

--- a/hashtagmap-admin/build.gradle
+++ b/hashtagmap-admin/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-    compile project(':hashtagmap-core')
-    compile project(':hashtagmap-kakao-scheduler')
-    compile project(':hashtagmap-instagram-scheduler')
-    compile project(':hashtagmap-crawling-scheduler')
+    implementation project(':hashtagmap-core')
+    implementation project(':hashtagmap-kakao-scheduler')
+    implementation project(':hashtagmap-instagram-scheduler')
+    implementation project(':hashtagmap-crawling-scheduler')
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/hashtagmap-crawling-scheduler/build.gradle
+++ b/hashtagmap-crawling-scheduler/build.gradle
@@ -2,6 +2,6 @@ bootJar { enabled = false }
 jar { enabled = true }
 
 dependencies {
-    compile project(':hashtagmap-core')
-    compile project(':hashtagmap-instagram-crawler')
+    implementation project(':hashtagmap-core')
+    implementation project(':hashtagmap-instagram-crawler')
 }

--- a/hashtagmap-instagram-crawler/build.gradle
+++ b/hashtagmap-instagram-crawler/build.gradle
@@ -5,3 +5,26 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.13.1'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
 }
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = 'PACKAGE'
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            limit {
+                counter = 'INSTRUCTION'
+                value = 'COVEREDRATIO'
+                minimum = 0.70
+            }
+
+            excludes = []
+        }
+    }
+}

--- a/hashtagmap-instagram-scheduler/build.gradle
+++ b/hashtagmap-instagram-scheduler/build.gradle
@@ -2,6 +2,6 @@ bootJar { enabled = false }
 jar { enabled = true }
 
 dependencies {
-    compile project(':hashtagmap-core')
-    compile project(':hashtagmap-instagram-api')
+    implementation project(':hashtagmap-core')
+    implementation project(':hashtagmap-instagram-api')
 }

--- a/hashtagmap-kakao-api/build.gradle
+++ b/hashtagmap-kakao-api/build.gradle
@@ -5,3 +5,26 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.1'
 }
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = 'PACKAGE'
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.60
+            }
+
+            limit {
+                counter = 'INSTRUCTION'
+                value = 'COVEREDRATIO'
+                minimum = 0.70
+            }
+
+            excludes = []
+        }
+    }
+}

--- a/hashtagmap-kakao-scheduler/build.gradle
+++ b/hashtagmap-kakao-scheduler/build.gradle
@@ -2,6 +2,6 @@ bootJar { enabled = false }
 jar { enabled = true }
 
 dependencies {
-    compile project(':hashtagmap-core')
-    compile project(':hashtagmap-kakao-api')
+    implementation project(':hashtagmap-core')
+    implementation project(':hashtagmap-kakao-api')
 }

--- a/hashtagmap-web/build.gradle
+++ b/hashtagmap-web/build.gradle
@@ -1,6 +1,24 @@
 dependencies {
-    compile project(':hashtagmap-core')
+    implementation project(':hashtagmap-core')
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.20
+            }
+
+            excludes = []
+        }
+
+    }
 }

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
- 각 모듈 별 독립적으로 커버리지 수치 설정
- lombok.config 파일을 추가해 lombok 으로 생성한 메서드는 리포트 대상에서 제외
- 모듈간의 의존을 implementation 으로 수정

fixes: #29 