### PR TITLE
[FEAT] Kakao 가게 데이터 unique key 예외 처리

### DIFF
--- a/hashtagmap-core/build.gradle
+++ b/hashtagmap-core/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'com.ewerk.gradle.plugins.querydsl'
 
 dependencies {
     compile 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'com.querydsl:querydsl-jpa'
 
     runtimeOnly 'mysql:mysql-connector-java'

--- a/hashtagmap-core/src/main/java/com/songpapeople/hashtagmap/place/domain/model/Place.java
+++ b/hashtagmap-core/src/main/java/com/songpapeople/hashtagmap/place/domain/model/Place.java
@@ -34,6 +34,5 @@ public class Place extends BaseEntity {
         this.location = location;
         this.placeName = placeName;
         this.placeUrl = placeUrl;
-
     }
 }

--- a/hashtagmap-core/src/main/java/com/songpapeople/hashtagmap/place/domain/repository/PlaceRepository.java
+++ b/hashtagmap-core/src/main/java/com/songpapeople/hashtagmap/place/domain/repository/PlaceRepository.java
@@ -3,5 +3,5 @@ package com.songpapeople.hashtagmap.place.domain.repository;
 import com.songpapeople.hashtagmap.place.domain.model.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PlaceRepository extends JpaRepository<Place, Long> {
+public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceRepositoryCustom {
 }

--- a/hashtagmap-core/src/main/java/com/songpapeople/hashtagmap/place/domain/repository/PlaceRepositoryCustom.java
+++ b/hashtagmap-core/src/main/java/com/songpapeople/hashtagmap/place/domain/repository/PlaceRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.songpapeople.hashtagmap.place.domain.repository;
+
+import com.songpapeople.hashtagmap.place.domain.model.Place;
+
+import java.util.List;
+
+public interface PlaceRepositoryCustom {
+    void updateAndInsert(List<Place> places);
+}

--- a/hashtagmap-core/src/main/java/com/songpapeople/hashtagmap/place/domain/repository/PlaceRepositoryCustomImpl.java
+++ b/hashtagmap-core/src/main/java/com/songpapeople/hashtagmap/place/domain/repository/PlaceRepositoryCustomImpl.java
@@ -1,0 +1,54 @@
+package com.songpapeople.hashtagmap.place.domain.repository;
+
+import com.songpapeople.hashtagmap.place.domain.model.Place;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class PlaceRepositoryCustomImpl implements PlaceRepositoryCustom {
+    private static final String SQL = "INSERT INTO place " +
+            "(category, kakao_id, latitude, longitude, road_address_name, place_name, place_url) " +
+            "VALUES (:category, :kakao_id, :latitude, :longitude, :road_address_name, :place_name, :place_url) " +
+            "ON DUPLICATE KEY UPDATE " +
+            "category = VALUES(category), " +
+            "latitude = VALUES(latitude), " +
+            "longitude = VALUES(longitude), " +
+            "road_address_name = VALUES(road_address_name), " +
+            "place_name = VALUES(place_name), " +
+            "place_url = VALUES(place_url);";
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    public PlaceRepositoryCustomImpl(NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
+        this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
+    }
+
+    @Override
+    public void updateAndInsert(List<Place> places) {
+        List<Map<String, Object>> batchValues = setParameters(places);
+
+        namedParameterJdbcTemplate.batchUpdate(SQL, batchValues.toArray(new Map[places.size()]));
+    }
+
+    private List<Map<String, Object>> setParameters(List<Place> places) {
+        List<Map<String, Object>> batchValues = new ArrayList<>(places.size());
+        for (Place place : places) {
+            batchValues.add(
+                    new MapSqlParameterSource()
+                            .addValue("category", place.getCategory().toString())
+                            .addValue("kakao_id", place.getKakaoId())
+                            .addValue("latitude", place.getLocation().getPoint().getLatitude())
+                            .addValue("longitude", place.getLocation().getPoint().getLongitude())
+                            .addValue("road_address_name", place.getLocation().getRoadAddressName())
+                            .addValue("place_name", place.getPlaceName())
+                            .addValue("place_url", place.getPlaceUrl())
+                            .getValues()
+            );
+        }
+
+        return batchValues;
+    }
+}

--- a/hashtagmap-core/src/test/java/com/songpapeople/hashtagmap/place/domain/repository/PlaceRepositoryTest.java
+++ b/hashtagmap-core/src/test/java/com/songpapeople/hashtagmap/place/domain/repository/PlaceRepositoryTest.java
@@ -1,0 +1,94 @@
+package com.songpapeople.hashtagmap.place.domain.repository;
+
+import com.songpapeople.hashtagmap.place.domain.model.Category;
+import com.songpapeople.hashtagmap.place.domain.model.Location;
+import com.songpapeople.hashtagmap.place.domain.model.Place;
+import com.songpapeople.hashtagmap.place.domain.model.Point;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+public class PlaceRepositoryTest {
+    private static final String ROAD_ADDRESS_NAME = "서울시 송파구";
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @BeforeEach
+    private void setUp() {
+        List<Place> places = Arrays.asList(
+                Place.builder()
+                        .id(1L)
+                        .kakaoId("1234")
+                        .category(Category.CAFE)
+                        .location(new Location(new Point("33", "127"), ROAD_ADDRESS_NAME))
+                        .placeName("starbucks")
+                        .build(),
+                Place.builder()
+                        .id(2L)
+                        .kakaoId("1423")
+                        .category(Category.CAFE)
+                        .location(new Location(new Point("33.5", "127.5"), ROAD_ADDRESS_NAME))
+                        .placeName("mahogani")
+                        .build(),
+                Place.builder()
+                        .id(3L)
+                        .kakaoId("1324")
+                        .category(Category.CAFE)
+                        .location(new Location(new Point("33.2", "127.2"), ROAD_ADDRESS_NAME))
+                        .placeName("cu")
+                        .build()
+        );
+        placeRepository.saveAll(places);
+    }
+
+    @DisplayName("중복된 kakao_id를 가진 place를 저장할 때 예외를 발생시키지 않고 업데이트 시키기")
+    @Test
+    void updateInsertQueryTest() {
+        List<Place> duplicateKakaoIdPlaces = Arrays.asList(
+                Place.builder()
+                        .id(1L)
+                        .kakaoId("1234")
+                        .category(Category.CAFE)
+                        .location(new Location(new Point("33", "127"), ROAD_ADDRESS_NAME))
+                        .placeName("starbucks2")
+                        .build(),
+                Place.builder()
+                        .id(2L)
+                        .kakaoId("1423")
+                        .category(Category.CAFE)
+                        .location(new Location(new Point("33.5", "127.5"), ROAD_ADDRESS_NAME))
+                        .placeName("mahogani2")
+                        .build(),
+                Place.builder()
+                        .id(3L)
+                        .kakaoId("1324")
+                        .category(Category.CAFE)
+                        .location(new Location(new Point("33.2", "127.2"), ROAD_ADDRESS_NAME))
+                        .placeName("cu")
+                        .build()
+        );
+        placeRepository.updateAndInsert(duplicateKakaoIdPlaces);
+
+        assertAll(
+                () -> assertThat(placeRepository.findById(1L).get().getPlaceName()).isEqualTo("starbucks2"),
+                () -> assertThat(placeRepository.findById(2L).get().getPlaceName()).isEqualTo("mahogani2"),
+                () -> assertThat(placeRepository.findById(3L).get().getPlaceName()).isEqualTo("cu")
+        );
+    }
+
+    @AfterEach
+    private void tearDown() {
+        placeRepository.deleteAll();
+    }
+}

--- a/hashtagmap-kakao-scheduler/src/main/java/com/songpapeople/hashtagmap/scheduler/domain/KakaoSchedulerTask.java
+++ b/hashtagmap-kakao-scheduler/src/main/java/com/songpapeople/hashtagmap/scheduler/domain/KakaoSchedulerTask.java
@@ -32,7 +32,6 @@ public class KakaoSchedulerTask {
         this.kakaoApiService = kakaoApiService;
     }
 
-    // TODO: 2020/07/23 데이터를 받았을 때 기존 데이터 업데이트, 갱신 로직이 필요하다.
     @Transactional
     public void collectData() {
         List<Zone> zones = zoneRepository.findByActivated();
@@ -50,7 +49,7 @@ public class KakaoSchedulerTask {
                 .collect(Collectors.toSet());
         List<Place> places = PlaceFactory.from(documents);
 
-        placeRepository.saveAll(places);
+        placeRepository.updateAndInsert(places);
     }
 
     private List<KakaoPlaceDto> findPlacesByRect(Category category, Rect rect) {

--- a/hashtagmap-kakao-scheduler/src/test/java/com/songpapeople/hashtagmap/scheduler/domain/KakaoSchedulerTaskMockTest.java
+++ b/hashtagmap-kakao-scheduler/src/test/java/com/songpapeople/hashtagmap/scheduler/domain/KakaoSchedulerTaskMockTest.java
@@ -1,0 +1,126 @@
+package com.songpapeople.hashtagmap.scheduler.domain;
+
+import com.songpapeople.hashtagmap.kakaoapi.domain.dto.Document;
+import com.songpapeople.hashtagmap.kakaoapi.domain.dto.KakaoPlaceDto;
+import com.songpapeople.hashtagmap.kakaoapi.service.KakaoApiService;
+import com.songpapeople.hashtagmap.place.domain.model.*;
+import com.songpapeople.hashtagmap.place.domain.repository.PlaceRepository;
+import com.songpapeople.hashtagmap.place.domain.repository.ZoneRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+public class KakaoSchedulerTaskMockTest {
+    @Mock
+    private KakaoApiService kakaoApiService;
+
+    @Mock
+    private ZoneRepository zoneRepository;
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    private KakaoSchedulerTask kakaoSchedulerTask;
+
+    @BeforeEach
+    private void setUpd() {
+        List<Place> places = Arrays.asList(
+                Place.builder()
+                        .kakaoId("123")
+                        .category(Category.CAFE)
+                        .location(new Location(new Point("33", "127"), "서울시 송파구"))
+                        .placeName("starbucks")
+                        .placeUrl("http://starbucks.com")
+                        .build(),
+                Place.builder()
+                        .kakaoId("124")
+                        .category(Category.CAFE)
+                        .location(new Location(new Point("33.1", "127.1"), "서울시 송파구"))
+                        .placeName("mahogani")
+                        .placeUrl("http://mahogani.com")
+                        .build()
+        );
+        placeRepository.saveAll(places);
+
+        kakaoSchedulerTask = new KakaoSchedulerTask(zoneRepository, placeRepository, kakaoApiService);
+    }
+
+    @DisplayName("변경된 가게 데이터 저장 시 해당 가게 정보 업데이트")
+    @Test
+    void updateAndInsertPlaceTest() {
+        List<Zone> zones = Collections.singletonList(
+                Zone.builder()
+                        .topLeft(new Point("33.02", "127.04"))
+                        .bottomRight(new Point("33.04", "127.02"))
+                        .district(new District("서울시 송파구"))
+                        .isActivated(true)
+                        .build()
+        );
+        when(zoneRepository.findByActivated()).thenReturn(zones);
+
+        List<KakaoPlaceDto> kakaoPlaceDtos = Arrays.asList(
+                new KakaoPlaceDto(null,
+                        Arrays.asList(
+                                Document.builder()
+                                        .id("123")
+                                        .categoryGroupCode("CE7")
+                                        .placeName("woowacourse")
+                                        .placeUrl("http://woowacourse.com")
+                                        .roadAddressName("서울시 송파구")
+                                        .x("33")
+                                        .y("127")
+                                        .build(),
+                                Document.builder()
+                                        .id("124")
+                                        .categoryGroupCode("CE7")
+                                        .placeName("mahogani")
+                                        .placeUrl("http://mahogani.com")
+                                        .roadAddressName("서울시 송파구")
+                                        .x("33.1")
+                                        .y("127.1")
+                                        .build()
+                        ))
+        );
+        when(kakaoApiService.findPlaces(any(), any())).thenReturn(kakaoPlaceDtos);
+
+        kakaoSchedulerTask.collectData();
+
+        List<Place> updatedPlaces = placeRepository.findAll();
+        Place updatePlace = updatedPlaces.stream()
+                .filter(place -> place.getKakaoId().equals("123"))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+        Place nonUpdatePlace = updatedPlaces.stream()
+                .filter(place -> place.getKakaoId().equals("124"))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+        assertAll(
+                () -> assertThat(updatedPlaces).hasSize(2),
+                () -> assertThat(updatePlace.getPlaceName()).isEqualTo("woowacourse"),
+                () -> assertThat(updatePlace.getPlaceUrl()).isEqualTo("http://woowacourse.com"),
+                () -> assertThat(nonUpdatePlace.getPlaceName()).isEqualTo("mahogani")
+        );
+    }
+
+    @AfterEach
+    private void tearDown() {
+        placeRepository.deleteAll();
+    }
+}

--- a/hashtagmap-kakao-scheduler/src/test/java/com/songpapeople/hashtagmap/scheduler/domain/KakaoSchedulerTaskMockTest.java
+++ b/hashtagmap-kakao-scheduler/src/test/java/com/songpapeople/hashtagmap/scheduler/domain/KakaoSchedulerTaskMockTest.java
@@ -40,7 +40,7 @@ public class KakaoSchedulerTaskMockTest {
     private KakaoSchedulerTask kakaoSchedulerTask;
 
     @BeforeEach
-    private void setUpd() {
+    private void setUp() {
         List<Place> places = Arrays.asList(
                 Place.builder()
                         .kakaoId("123")

--- a/hashtagmap-kakao-scheduler/src/test/java/com/songpapeople/hashtagmap/scheduler/domain/KakaoSchedulerTaskTest.java
+++ b/hashtagmap-kakao-scheduler/src/test/java/com/songpapeople/hashtagmap/scheduler/domain/KakaoSchedulerTaskTest.java
@@ -46,7 +46,7 @@ public class KakaoSchedulerTaskTest {
     @Disabled
     @DisplayName("Task Test - 실제 Kakao Api 호출")
     @Test
-    public void collectDataTest() {
+    void collectDataTest() {
         kakaoSchedulerTask.collectData();
 
         List<Place> result = placeRepository.findAll();


### PR DESCRIPTION
- mysql에서 적용 가능한 ```ON DUPLICATE KEY UPDATE``` 쿼리를 이용해서 문제를 해결했습니다.

- native sql을 작성해야 해서 ```spring-boot-starter-jdbc``` 의존성을  ```hashtagmap-core``` 모듈에 추가했습니다.

- native sql을 h2 데이터베이스에 적용하기 위해서 jdbc-url에 ```MODE=MYSQL;``` 을 추가해주었습니다.
테스트를 수행하기 전에 서브모듈 정보를 업데이트해야 합니다.

- KakaoSchedulerTask를 테스트할 때는 Mock을 이용해서 저장되어 있는 기존의 가게 정보가 변경되는지 확인했습니다.

fixes: #100 

