### PR TITLE
[FEAT] 말풍선 다 띄우기 & 말풍선 인식 범위 줄이기 & 태그레벨 필터링 버그 수정

### DIFF
--- a/hashtagmap-web/front/src/assets/css/textBalloon.css
+++ b/hashtagmap-web/front/src/assets/css/textBalloon.css
@@ -1,4 +1,4 @@
-.marker-box {
+.text-balloon-box {
   bottom: 77px;
   border-radius: 30px / 30px;
   box-shadow: 0 4px 15px 0 rgba(45, 54, 65, 0.5);
@@ -6,7 +6,7 @@
   min-width: 150px;
 }
 
-.marker-box::after {
+.text-balloon-box::after {
   border-left: 11px solid transparent;
   border-top: 13px solid white;
   border-right: 11px solid transparent;
@@ -16,15 +16,15 @@
   right: 63px;
 }
 
-.marker-box:hover {
+.text-balloon-box:hover {
   box-shadow: 0 4px 15px 0 rgba(45, 54, 65, 0.75);
 }
 
-.marker-title {
+.text-balloon-title {
   width: auto;
   right: 90%;
 }
 
-.marker-text {
+.text-balloon-text {
   font-weight: bold;
 }

--- a/hashtagmap-web/front/src/assets/css/textBalloon.css
+++ b/hashtagmap-web/front/src/assets/css/textBalloon.css
@@ -1,5 +1,4 @@
 .marker-box {
-  position: relative;
   bottom: 77px;
   border-radius: 30px / 30px;
   box-shadow: 0 4px 15px 0 rgba(45, 54, 65, 0.5);

--- a/hashtagmap-web/front/src/assets/css/textBalloon.css
+++ b/hashtagmap-web/front/src/assets/css/textBalloon.css
@@ -26,10 +26,6 @@
   right: 90%;
 }
 
-.marker-title:hover {
-  text-decoration: underline;
-}
-
 .marker-text {
   font-weight: bold;
 }

--- a/hashtagmap-web/front/src/store/index.js
+++ b/hashtagmap-web/front/src/store/index.js
@@ -160,5 +160,6 @@ export default new Vuex.Store({
       });
     },
   },
+
   modules: {},
 });

--- a/hashtagmap-web/front/src/store/index.js
+++ b/hashtagmap-web/front/src/store/index.js
@@ -55,7 +55,7 @@ export default new Vuex.Store({
         active: true,
       },
     ],
-    markerDetails: [],
+    mapOverlays: [],
     categories: [
       {
         name: CATEGORY.CAFE,
@@ -89,8 +89,8 @@ export default new Vuex.Store({
         t.level === tagLevel.level ? { ...t, active: !tagLevel.active } : t,
       );
     },
-    ADD_MARKER_DETAIL(state, markerDetail) {
-      state.markerDetails.push(markerDetail);
+    ADD_MAP_OVERLAYS(state, overlayObj) {
+      state.mapOverlays.push(overlayObj);
     },
     SET_CATEGORY(state, category) {
       state.categories = state.categories.map(c =>
@@ -98,7 +98,6 @@ export default new Vuex.Store({
           ? { ...c, active: !category.active }
           : { ...c, active: true },
       );
-    },
   },
 
   actions: {
@@ -150,19 +149,20 @@ export default new Vuex.Store({
       const activeTagLevels = state.tagLevels
         .filter(tagLevel => tagLevel.active)
         .map(tagLevel => tagLevel.level);
-      return state.markerDetails.filter(markerDetail => {
-        if (activeTagLevels.includes(markerDetail.place.tagLevel)) {
-          return state.markerDetails.filter(markerDetail => {
-            if (
-              activeTagLevels.includes(markerDetail.tagLevel) &&
-              activeCategory.includes(markerDetail.category)
-            ) {
-              markerDetail.marker.setMap(state.kakaoMap);
-              markerDetail.textBalloon.setMap(state.kakaoMap);
-              markerDetail.textBalloon.setZIndex(1);
-            } else {
-              markerDetail.marker.setMap(null);
-              markerDetail.textBalloon.setMap(null);
+      return state.mapOverlays.filter(mapOverlay => {
+          if (activeTagLevels.includes(markerDetail.place.tagLevel)) {
+              return state.markerDetails.filter(markerDetail => {
+                      if (
+                          activeTagLevels.includes(markerDetail.tagLevel) &&
+                          activeCategory.includes(markerDetail.category)
+                      ) {
+          mapOverlay.marker.setMap(state.kakaoMap);
+          mapOverlay.textBalloon.setMap(state.kakaoMap);
+          mapOverlay.textBalloon.setZIndex(1);
+        } else {
+          mapOverlay.marker.setMap(null);
+          mapOverlay.textBalloon.setMap(null);
+
             }
           });
         }

--- a/hashtagmap-web/front/src/store/index.js
+++ b/hashtagmap-web/front/src/store/index.js
@@ -151,13 +151,20 @@ export default new Vuex.Store({
         .filter(tagLevel => tagLevel.active)
         .map(tagLevel => tagLevel.level);
       return state.markerDetails.filter(markerDetail => {
-        if (
-          activeTagLevels.includes(markerDetail.tagLevel) &&
-          activeCategory.includes(markerDetail.category)
-        ) {
-          markerDetail.marker.setMap(state.kakaoMap);
-        } else {
-          markerDetail.marker.setMap(null);
+        if (activeTagLevels.includes(markerDetail.place.tagLevel)) {
+          return state.markerDetails.filter(markerDetail => {
+            if (
+              activeTagLevels.includes(markerDetail.tagLevel) &&
+              activeCategory.includes(markerDetail.category)
+            ) {
+              markerDetail.marker.setMap(state.kakaoMap);
+              markerDetail.textBalloon.setMap(state.kakaoMap);
+              markerDetail.textBalloon.setZIndex(1);
+            } else {
+              markerDetail.marker.setMap(null);
+              markerDetail.textBalloon.setMap(null);
+            }
+          });
         }
       });
     },

--- a/hashtagmap-web/front/src/store/index.js
+++ b/hashtagmap-web/front/src/store/index.js
@@ -55,7 +55,6 @@ export default new Vuex.Store({
         active: true,
       },
     ],
-    mapOverlays: [],
     categories: [
       {
         name: CATEGORY.CAFE,
@@ -66,6 +65,7 @@ export default new Vuex.Store({
         active: true,
       },
     ],
+    mapOverlays: [],
   },
 
   mutations: {
@@ -89,15 +89,16 @@ export default new Vuex.Store({
         t.level === tagLevel.level ? { ...t, active: !tagLevel.active } : t,
       );
     },
-    ADD_MAP_OVERLAYS(state, overlayObj) {
-      state.mapOverlays.push(overlayObj);
-    },
     SET_CATEGORY(state, category) {
       state.categories = state.categories.map(c =>
         c.name === category.name
           ? { ...c, active: !category.active }
           : { ...c, active: true },
       );
+    },
+    ADD_MAP_OVERLAYS(state, overlayObj) {
+      state.mapOverlays.push(overlayObj);
+    },
   },
 
   actions: {
@@ -113,13 +114,8 @@ export default new Vuex.Store({
       commit("SET_DETAIL_MODAL", detailModal);
     },
     async setPlaces({ commit }) {
-      try {
-        const places = await axios.get("/markers");
-        commit("SET_PLACES", places.data.data);
-      } catch (error) {
-        // todo : 스낵바로 에러내용 출력
-        alert(error);
-      }
+      const places = await axios.get("/markers");
+      commit("SET_PLACES", places.data.data);
     },
   },
 
@@ -142,7 +138,7 @@ export default new Vuex.Store({
     getCategories: state => {
       return state.categories;
     },
-    activeMarker: state => {
+    activeOverlays: state => {
       const activeCategory = state.categories
         .filter(category => category.active)
         .map(category => category.name);
@@ -150,25 +146,19 @@ export default new Vuex.Store({
         .filter(tagLevel => tagLevel.active)
         .map(tagLevel => tagLevel.level);
       return state.mapOverlays.filter(mapOverlay => {
-          if (activeTagLevels.includes(markerDetail.place.tagLevel)) {
-              return state.markerDetails.filter(markerDetail => {
-                      if (
-                          activeTagLevels.includes(markerDetail.tagLevel) &&
-                          activeCategory.includes(markerDetail.category)
-                      ) {
+        if (
+          activeTagLevels.includes(mapOverlay.place.tagLevel) &&
+          activeCategory.includes(mapOverlay.place.category)
+        ) {
           mapOverlay.marker.setMap(state.kakaoMap);
           mapOverlay.textBalloon.setMap(state.kakaoMap);
           mapOverlay.textBalloon.setZIndex(1);
         } else {
           mapOverlay.marker.setMap(null);
           mapOverlay.textBalloon.setMap(null);
-
-            }
-          });
         }
       });
     },
   },
-
   modules: {},
 });

--- a/hashtagmap-web/front/src/utils/templates.js
+++ b/hashtagmap-web/front/src/utils/templates.js
@@ -1,8 +1,34 @@
-export const textBalloonTemplate = place =>
-  `<div id="${place.kakaoId}" class="btn marker-box">` +
-  `  <div>` +
-  `    <div class="marker-title">${place.placeName}` +
-  `    </div>` +
-  `    <div class="marker-text">#${place.hashtagCount}</div>` +
-  `  </div>` +
-  `</div>`;
+export const textBalloonTemplate = place => {
+  let $textBalloonElement = createTextBalloonElement(place);
+  let $container = createDivElement();
+  const $markerTitleElement = createMarkerTitleElement(place);
+  const $hashTagCountElement = createHashtagCountElement(place);
+  $textBalloonElement.appendChild($container);
+  $container.appendChild($markerTitleElement);
+  $container.appendChild($hashTagCountElement);
+  return $textBalloonElement;
+};
+const createTextBalloonElement = place => {
+  let $textBalloonContent = createDivElement;
+  $textBalloonContent.id = place.kakaoId;
+  $textBalloonContent.className = "btn text-balloon-box";
+  return $textBalloonContent;
+};
+
+const createMarkerTitleElement = place => {
+  let $markerTitle = createDivElement;
+  $markerTitle.className = "text-balloon-title";
+  $markerTitle.textContent = place.placeName;
+  return $markerTitle;
+};
+
+const createHashtagCountElement = place => {
+    let $hashtagCount = createDivElement;
+    $hashtagCount.className = "text-balloon-text";
+    $hashtagCount.textContent = place.hashtagCount;
+    return $hashtagCount;
+};
+
+const createDivElement = () => {
+  return document.createElement("div");
+};

--- a/hashtagmap-web/front/src/utils/templates.js
+++ b/hashtagmap-web/front/src/utils/templates.js
@@ -7,7 +7,7 @@ export const textBalloonTemplate = place => {
 
   let $textBalloonTitle = document.createElement("div");
   $textBalloonTitle.className = "text-balloon-title";
-  $textBalloonTitle.textContent = place.placeName;
+  $textBalloonTitle.textContent = "#" + place.placeName;
 
   let $hashtagCount = document.createElement("div");
   $hashtagCount.className = "text-balloon-text";

--- a/hashtagmap-web/front/src/utils/templates.js
+++ b/hashtagmap-web/front/src/utils/templates.js
@@ -1,34 +1,20 @@
 export const textBalloonTemplate = place => {
-  let $textBalloonElement = createTextBalloonElement(place);
-  let $container = createDivElement();
-  const $markerTitleElement = createMarkerTitleElement(place);
-  const $hashTagCountElement = createHashtagCountElement(place);
+  let $textBalloonElement = document.createElement("div");
+  $textBalloonElement.id = place.kakaoId;
+  $textBalloonElement.className = "btn text-balloon-box";
+
+  let $container = document.createElement("div");
+
+  let $textBalloonTitle = document.createElement("div");
+  $textBalloonTitle.className = "text-balloon-title";
+  $textBalloonTitle.textContent = place.placeName;
+
+  let $hashtagCount = document.createElement("div");
+  $hashtagCount.className = "text-balloon-text";
+  $hashtagCount.textContent = place.hashtagCount;
+
   $textBalloonElement.appendChild($container);
-  $container.appendChild($markerTitleElement);
-  $container.appendChild($hashTagCountElement);
+  $container.appendChild($textBalloonTitle);
+  $container.appendChild($hashtagCount);
   return $textBalloonElement;
-};
-const createTextBalloonElement = place => {
-  let $textBalloonContent = createDivElement;
-  $textBalloonContent.id = place.kakaoId;
-  $textBalloonContent.className = "btn text-balloon-box";
-  return $textBalloonContent;
-};
-
-const createMarkerTitleElement = place => {
-  let $markerTitle = createDivElement;
-  $markerTitle.className = "text-balloon-title";
-  $markerTitle.textContent = place.placeName;
-  return $markerTitle;
-};
-
-const createHashtagCountElement = place => {
-    let $hashtagCount = createDivElement;
-    $hashtagCount.className = "text-balloon-text";
-    $hashtagCount.textContent = place.hashtagCount;
-    return $hashtagCount;
-};
-
-const createDivElement = () => {
-  return document.createElement("div");
 };

--- a/hashtagmap-web/front/src/views/KakaoMap.vue
+++ b/hashtagmap-web/front/src/views/KakaoMap.vue
@@ -37,7 +37,7 @@ export default {
     ...mapMutations(["SET_KAKAO_MAP_API", "SET_KAKAO_MAP", "ADD_MAP_OVERLAYS"]),
     ...mapActions(["setDetailModal", "setPlaces"]),
     async setMapOverlays() {
-      await this.places.map(place => {
+      await this.getPlaces.map(place => {
         const marker = this.createMaker(place);
         const textBalloon = this.createTextBalloon(place, marker);
         this.ADD_MAP_OVERLAYS({ place, marker, textBalloon });
@@ -50,7 +50,10 @@ export default {
         imageSize,
       );
       return new this.getKakaoMapApi.Marker({
-        position: new this.getKakaoMapApi.LatLng(place.latitude, place.longitude),
+        position: new this.getKakaoMapApi.LatLng(
+          place.latitude,
+          place.longitude,
+        ),
         title: place.placeName,
         image: markerImage,
       });
@@ -58,7 +61,7 @@ export default {
     createTextBalloon(place, marker) {
       const $content = textBalloonTemplate(place);
       this.onAddModalToTextBalloon(place, $content);
-      return new this.kakaoMapApi.CustomOverlay({
+      return new this.getKakaoMapApi.CustomOverlay({
         content: $content,
         position: marker.getPosition(),
         yAnchor: 2,

--- a/hashtagmap-web/front/src/views/KakaoMap.vue
+++ b/hashtagmap-web/front/src/views/KakaoMap.vue
@@ -55,17 +55,6 @@ export default {
         });
       });
     },
-    onAddTextBalloonToMarker(kakaoMap, place, textBalloon) {
-      textBalloon.setMap(kakaoMap);
-      const $textBalloon = document.getElementById(`${place.kakaoId}`);
-      $textBalloon.addEventListener(EVENT_TYPE.CLICK, event => {
-        if (event.target.classList.contains("marker-title")) {
-          this.onAddModalToTextBalloon(event, place);
-        } else {
-          textBalloon.setMap(null);
-        }
-      });
-    },
     onAddModalToTextBalloon(event, place) {
       event.preventDefault();
       this.setDetailModal(place);

--- a/hashtagmap-web/front/src/views/KakaoMap.vue
+++ b/hashtagmap-web/front/src/views/KakaoMap.vue
@@ -25,7 +25,7 @@ export default {
 
   mounted() {
     this.$store.watch(() => {
-      this.$store.getters.activeMarker;
+       this.$store.getters.activeMarker;
     });
   },
 

--- a/hashtagmap-web/front/src/views/KakaoMap.vue
+++ b/hashtagmap-web/front/src/views/KakaoMap.vue
@@ -19,13 +19,13 @@ export default {
     this.SET_KAKAO_MAP_API(await this.$initKakaoMapApi());
     this.SET_KAKAO_MAP(this.$loadMap());
     await this.setPlaces();
-    this.loadMarker();
+    this.setMapOverlays();
     this.$loadCurrentPosition();
   },
 
   mounted() {
     this.$store.watch(() => {
-       this.$store.getters.activeMarker;
+      this.$store.getters.activeOverlays;
     });
   },
 
@@ -34,30 +34,14 @@ export default {
   },
 
   methods: {
-    ...mapMutations([
-      "SET_KAKAO_MAP_API",
-      "SET_KAKAO_MAP",
-      "ADD_MARKER_DETAIL",
-    ]),
+    ...mapMutations(["SET_KAKAO_MAP_API", "SET_KAKAO_MAP", "ADD_MAP_OVERLAYS"]),
     ...mapActions(["setDetailModal", "setPlaces"]),
-    loadMarker() {
-      this.getPlaces.map(place => {
+    async setMapOverlays() {
+      await this.places.map(place => {
         const marker = this.createMaker(place);
-        marker.setMap(this.getKakaoMap);
-        this.ADD_MARKER_DETAIL({
-          marker,
-          tagLevel: place.tagLevel,
-          category: place.category,
-        });
         const textBalloon = this.createTextBalloon(place, marker);
-        this.getKakaoMapApi.event.addListener(marker, EVENT_TYPE.CLICK, () => {
-          this.onAddTextBalloonToMarker(this.getKakaoMap, place, textBalloon);
-        });
+        this.ADD_MAP_OVERLAYS({ place, marker, textBalloon });
       });
-    },
-    onAddModalToTextBalloon(event, place) {
-      event.preventDefault();
-      this.setDetailModal(place);
     },
     createMaker(place) {
       const imageSize = new this.getKakaoMapApi.Size(SIZE.width, SIZE.height);
@@ -73,13 +57,17 @@ export default {
     },
     createTextBalloon(place, marker) {
       const $content = textBalloonTemplate(place);
+      this.onAddModalToTextBalloon(place, $content);
+      return new this.kakaoMapApi.CustomOverlay({
+        content: $content,
+        position: marker.getPosition(),
+        yAnchor: 2,
+      });
+    },
+    onAddModalToTextBalloon(place, $content) {
       $content.addEventListener(EVENT_TYPE.CLICK, event => {
         event.preventDefault();
         this.setDetailModal(place);
-      });
-      return new his.getKakaoMapApi.CustomOverlay({
-        content: $content,
-        position: marker.getPosition(),
       });
     },
   },

--- a/hashtagmap-web/front/src/views/KakaoMap.vue
+++ b/hashtagmap-web/front/src/views/KakaoMap.vue
@@ -72,8 +72,13 @@ export default {
       });
     },
     createTextBalloon(place, marker) {
-      return new this.getKakaoMapApi.CustomOverlay({
-        content: textBalloonTemplate(place),
+      const $content = textBalloonTemplate(place);
+      $content.addEventListener(EVENT_TYPE.CLICK, event => {
+        event.preventDefault();
+        this.setDetailModal(place);
+      });
+      return new his.getKakaoMapApi.CustomOverlay({
+        content: $content,
         position: marker.getPosition(),
       });
     },

--- a/hashtagmap-web/front/src/views/KakaoMap.vue
+++ b/hashtagmap-web/front/src/views/KakaoMap.vue
@@ -36,8 +36,8 @@ export default {
   methods: {
     ...mapMutations(["SET_KAKAO_MAP_API", "SET_KAKAO_MAP", "ADD_MAP_OVERLAYS"]),
     ...mapActions(["setDetailModal", "setPlaces"]),
-    async setMapOverlays() {
-      await this.getPlaces.map(place => {
+    setMapOverlays() {
+      this.getPlaces.map(place => {
         const marker = this.createMaker(place);
         const textBalloon = this.createTextBalloon(place, marker);
         this.ADD_MAP_OVERLAYS({ place, marker, textBalloon });


### PR DESCRIPTION
- 말풍선 다 띄우는 걸로 수정, 종료 없음!
- 말풍선 어디든 클릭 시 모달 띄우는 걸로 수정
- 태그래밸 필터링 시 말풍선도 같이 지워지도록 수정
- 말풍선 인식 범위 줄이기 
    - 말풍선 css에서 position 때문이였음. css 수정 후, kakaoMapApi의 yAnchor속성으로 높이 수정
- 말풍선에 모달 이벤트 등록

말풍선을 document.getElementBy로 이벤트 등록을 해야 하는데,
계속 50개 밖에 못가져오길래 고생 좀 했슴다..
지도에서 현재 보이는 말풍선들만  html에 그려주기 때문에 그랬던 것이었어요.
api 문의하기 찾아봐서 문자열 html로 말풍선을 만들던 것을 element로 만들고 이벤트 등록하는 방법으로 수정했슴다.

fixes: #145