### PR TITLE
[BUG] 모달의 상세 정보 기능 오작동

### DIFF
--- a/hashtagmap-web/front/src/components/detail-modal/DetailModal.vue
+++ b/hashtagmap-web/front/src/components/detail-modal/DetailModal.vue
@@ -69,7 +69,7 @@ export default {
   methods: {
     ...mapMutations(["SET_DETAIL_MODAL_CLOSE"]),
     onClickPlaceName() {
-      let parsedPlaceName = this.detailModal.placeName.replace(/ /g, "");
+      let parsedPlaceName = this.getDetailModal.placeName.replace(/ /g, "");
       if (parsedPlaceName.endsWith("점")) {
         parsedPlaceName = parsedPlaceName.substr(0, parsedPlaceName.length - 1);
       }
@@ -78,7 +78,7 @@ export default {
       );
     },
     onClickModalDetail() {
-      return window.open(this.detailModal.placeUrl);
+      return window.open(this.getDetailModal.placeUrl);
     },
   },
 };


### PR DESCRIPTION
- 상세 정보를 눌렀을 때 카카오에서 제공하는 페이지로 이동합니다.
- 가게 이름 버튼을 눌렀을 때 해당 가게 이름으로 인스타그램에서 검색한 페이지로 이동합니다.

closed: #166 