### PR TITLE
[REFACTOR] : KakaoScheduler 동작방식 변경

### DIFF
--- a/hashtagmap-admin/build.gradle
+++ b/hashtagmap-admin/build.gradle
@@ -38,7 +38,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'INSTRUCTION'
                 value = 'COVEREDRATIO'
-                minimum = 0.30
+                minimum = 0.50
             }
 
             excludes = []

--- a/hashtagmap-admin/src/docs/asciidoc/api-guide.adoc
+++ b/hashtagmap-admin/src/docs/asciidoc/api-guide.adoc
@@ -27,15 +27,25 @@ operation::instagram/scheduler/update[snippets='http-request,http-response']
 == Kakao
 
 [[resources-kakao-scheduler-toggle]]
-=== scheduler toggle (ON/OFF)
+=== scheduler - ON/OFF
 
-operation::kakao/scheduler/start[snippets='http-request,request-fields,http-response']
-operation::kakao/scheduler/stop[snippets='http-request,request-fields,http-response']
+operation::kakao/scheduler/start[snippets='http-request,http-response']
+operation::kakao/scheduler/stop[snippets='http-request,http-response']
 
 [[resources-kakao-scheduler-status]]
 === scheduler 상태 조회
 
 operation::kakao/scheduler/status[snippets='http-request,request-parameters,http-response,response-fields']
+
+[[resources-kakao-scheduler-auto-runnable-toggle]]
+=== scheduler 자동 실행 - ON/OFF
+
+operation::kakao/scheduler/auto/toggle[snippets='http-request,request-fields,http-response']
+
+[[resources-kakao-scheduler-auto-runnable-status]]
+=== scheduler 자동 실행 상태 조회
+
+operation::kakao/scheduler/auto/status[snippets='http-request,request-parameters,http-response']
 
 [[resources-kakao-scheduler-period-put]]
 === scheduler 주기 변경

--- a/hashtagmap-admin/src/docs/asciidoc/api-guide.adoc
+++ b/hashtagmap-admin/src/docs/asciidoc/api-guide.adoc
@@ -29,7 +29,8 @@ operation::instagram/scheduler/update[snippets='http-request,http-response']
 [[resources-kakao-scheduler-toggle]]
 === scheduler toggle (ON/OFF)
 
-operation::kakao/scheduler/toggle[snippets='http-request,request-fields,http-response']
+operation::kakao/scheduler/start[snippets='http-request,request-fields,http-response']
+operation::kakao/scheduler/stop[snippets='http-request,request-fields,http-response']
 
 [[resources-kakao-scheduler-status]]
 === scheduler 상태 조회
@@ -45,6 +46,7 @@ operation::kakao/scheduler/period/put[snippets='http-request,http-response']
 === scheduler 주기 조회
 
 operation::kakao/scheduler/period/get[snippets='http-request,http-response,response-fields']
+
 [[resources-district]]
 == District
 

--- a/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/config/schedule/KakaoScheduleAutoConfiguration.java
+++ b/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/config/schedule/KakaoScheduleAutoConfiguration.java
@@ -1,29 +1,35 @@
 package com.songpapeople.hashtagmap.config.schedule;
 
+import com.songpapeople.hashtagmap.kakao.schedule.model.PeriodHistory;
 import com.songpapeople.hashtagmap.kakao.schedule.model.Schedule;
+import com.songpapeople.hashtagmap.kakao.schedule.repository.PeriodHistoryRepository;
 import com.songpapeople.hashtagmap.kakao.schedule.repository.ScheduleRepository;
 import com.songpapeople.hashtagmap.scheduler.domain.KakaoScheduler;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 
 import javax.annotation.PostConstruct;
 import java.util.Optional;
 
-@Configuration
+@Slf4j
 @RequiredArgsConstructor
+@Configuration
 public class KakaoScheduleAutoConfiguration {
     private static final String KAKAO = "KAKAO";
 
     private final KakaoScheduler kakaoScheduler;
     private final ScheduleRepository scheduleRepository;
+    private final PeriodHistoryRepository periodHistoryRepository;
 
     @PostConstruct
     public void configureKakaoSchedule() {
-        Optional<Schedule> kakao = scheduleRepository.findByName(KAKAO);
-        if (kakao.isPresent() && kakao.get().isActive()) {
+        log.info("AutoConfigure KakaoScheduler");
+        Optional<Schedule> kakaoSchedule = scheduleRepository.findByName(KAKAO);
+        if (kakaoSchedule.isPresent() && kakaoSchedule.get().isActive()) {
+            Optional<PeriodHistory> findPeriodHistory = periodHistoryRepository.findTopByOrderByChangedDateDesc();
+            findPeriodHistory.ifPresent(periodHistory -> kakaoScheduler.changePeriod(periodHistory.getExpression()));
             kakaoScheduler.start();
-            return;
         }
-        kakaoScheduler.stop();
     }
 }

--- a/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/controller/exceptionhandler/AdminExceptionControllerAdvice.java
+++ b/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/controller/exceptionhandler/AdminExceptionControllerAdvice.java
@@ -39,7 +39,7 @@ public class AdminExceptionControllerAdvice {
 
     @ExceptionHandler(InstagramSchedulerException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public CustomResponse<Void> methodArgumentNotValidException(InstagramSchedulerException e) {
+    public CustomResponse<Void> handleInstagramSchedulerException(InstagramSchedulerException e) {
         log.info("InstagramScheduler Exception : {}", e.getMessage());
         return CustomResponse.error(e.getErrorCode(), e.getMessage());
     }

--- a/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/exception/AdminException.java
+++ b/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/exception/AdminException.java
@@ -1,6 +1,10 @@
 package com.songpapeople.hashtagmap.exception;
 
 public class AdminException extends HashtagMapException {
+    public AdminException(final String errorMessage, final String errorCode) {
+        super(errorMessage, errorCode);
+    }
+
     public AdminException(AdminExceptionStatus adminExceptionStatus) {
         super(adminExceptionStatus.getMessage(), adminExceptionStatus.getCode());
     }

--- a/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/kakao/api/KakaoSchedulerApiController.java
+++ b/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/kakao/api/KakaoSchedulerApiController.java
@@ -28,22 +28,35 @@ public class KakaoSchedulerApiController {
 
     @PostMapping("/start")
     @ResponseStatus(HttpStatus.OK)
-    public CustomResponse<Void> startScheduler(@RequestBody @Valid final KakaoScheduleToggleDto kakaoScheduleToggleDto) {
-        kakaoScheduleCommandService.startSchedule(kakaoScheduleToggleDto.getName());
+    public CustomResponse<Void> startScheduler() {
+        kakaoScheduleCommandService.startSchedule();
         return CustomResponse.empty();
     }
 
     @PostMapping("/stop")
     @ResponseStatus(HttpStatus.OK)
-    public CustomResponse<Void> stopScheduler(@RequestBody @Valid final KakaoScheduleToggleDto kakaoScheduleToggleDto) {
-        kakaoScheduleCommandService.stopSchedule(kakaoScheduleToggleDto.getName());
+    public CustomResponse<Void> stopScheduler() {
+        kakaoScheduleCommandService.stopSchedule();
         return CustomResponse.empty();
     }
 
     @GetMapping("/status")
     @ResponseStatus(HttpStatus.OK)
-    public CustomResponse<Boolean> getActiveStatus(@RequestParam("name") String name) {
-        return CustomResponse.of(kakaoScheduleQueryService.getKakaoScheduleActiveStatus(name));
+    public CustomResponse<Boolean> getActiveStatus() {
+        return CustomResponse.of(kakaoScheduleQueryService.getKakaoScheduleActiveStatus());
+    }
+
+    @PostMapping("/auto/toggle")
+    @ResponseStatus(HttpStatus.OK)
+    public CustomResponse<Void> toggleAutoRunnable(@RequestBody @Valid KakaoScheduleToggleDto kakaoScheduleToggleDto) {
+        kakaoScheduleCommandService.toggleScheduleAutoRunnable(kakaoScheduleToggleDto.getName());
+        return CustomResponse.empty();
+    }
+
+    @GetMapping("/auto/status")
+    @ResponseStatus(HttpStatus.OK)
+    public CustomResponse<Boolean> getKakaoAutoRunnable(@RequestParam("name") String scheduleName) {
+        return CustomResponse.of(kakaoScheduleQueryService.getKakaoScheduleAutoRunnable(scheduleName));
     }
 
     @PutMapping("/period")

--- a/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/kakao/api/KakaoSchedulerApiController.java
+++ b/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/kakao/api/KakaoSchedulerApiController.java
@@ -26,10 +26,17 @@ public class KakaoSchedulerApiController {
     private final KakaoScheduleCommandService kakaoScheduleCommandService;
     private final KakaoScheduleQueryService kakaoScheduleQueryService;
 
-    @PostMapping("/toggle")
+    @PostMapping("/start")
     @ResponseStatus(HttpStatus.OK)
-    public CustomResponse<Void> toggleScheduler(@RequestBody @Valid final KakaoScheduleToggleDto kakaoScheduleToggleDto) {
-        kakaoScheduleCommandService.toggleSchedule(kakaoScheduleToggleDto.getName());
+    public CustomResponse<Void> startScheduler(@RequestBody @Valid final KakaoScheduleToggleDto kakaoScheduleToggleDto) {
+        kakaoScheduleCommandService.startSchedule(kakaoScheduleToggleDto.getName());
+        return CustomResponse.empty();
+    }
+
+    @PostMapping("/stop")
+    @ResponseStatus(HttpStatus.OK)
+    public CustomResponse<Void> stopScheduler(@RequestBody @Valid final KakaoScheduleToggleDto kakaoScheduleToggleDto) {
+        kakaoScheduleCommandService.stopSchedule(kakaoScheduleToggleDto.getName());
         return CustomResponse.empty();
     }
 

--- a/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleCommandService.java
+++ b/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleCommandService.java
@@ -19,13 +19,22 @@ public class KakaoScheduleCommandService {
     private final KakaoScheduler kakaoScheduler;
 
     @Transactional
-    public void toggleSchedule(String name) {
+    public void changeSchedulePeriod(String expression) {
+        historyRepository.save(new PeriodHistory(expression));
+        kakaoScheduler.changePeriod(expression);
+    }
+
+    @Transactional
+    public void startSchedule(final String name) {
         Schedule schedule = findScheduleByTarget(name);
         schedule.toggle();
-        if (schedule.isActive()) {
-            kakaoScheduler.start();
-            return;
-        }
+        kakaoScheduler.start();
+    }
+
+    @Transactional
+    public void stopSchedule(final String name) {
+        Schedule schedule = findScheduleByTarget(name);
+        schedule.toggle();
         kakaoScheduler.stop();
     }
 
@@ -35,10 +44,5 @@ public class KakaoScheduleCommandService {
                         AdminExceptionStatus.NOT_FOUND_SCHEDULER,
                         String.format("스케쥴러(%s)가 존재하지 않습니다.", name)
                 ));
-    }
-
-    public void changeSchedulePeriod(String expression) {
-        historyRepository.save(new PeriodHistory(expression));
-        kakaoScheduler.changePeriod(expression);
     }
 }

--- a/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleCommandService.java
+++ b/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleCommandService.java
@@ -25,24 +25,21 @@ public class KakaoScheduleCommandService {
     }
 
     @Transactional
-    public void startSchedule(final String name) {
-        Schedule schedule = findScheduleByTarget(name);
-        schedule.toggle();
-        kakaoScheduler.start();
-    }
-
-    @Transactional
-    public void stopSchedule(final String name) {
-        Schedule schedule = findScheduleByTarget(name);
-        schedule.toggle();
-        kakaoScheduler.stop();
-    }
-
-    private Schedule findScheduleByTarget(final String name) {
-        return scheduleRepository.findByName(name)
+    public void toggleScheduleAutoRunnable(final String name) {
+        Schedule schedule = scheduleRepository.findByName(name)
                 .orElseThrow(() -> new AdminException(
                         AdminExceptionStatus.NOT_FOUND_SCHEDULER,
                         String.format("스케쥴러(%s)가 존재하지 않습니다.", name)
                 ));
+        schedule.toggle();
     }
+
+    public void startSchedule() {
+        kakaoScheduler.start();
+    }
+
+    public void stopSchedule() {
+        kakaoScheduler.stop();
+    }
+
 }

--- a/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleQueryService.java
+++ b/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleQueryService.java
@@ -7,6 +7,7 @@ import com.songpapeople.hashtagmap.kakao.schedule.model.Schedule;
 import com.songpapeople.hashtagmap.kakao.schedule.repository.PeriodHistoryRepository;
 import com.songpapeople.hashtagmap.kakao.schedule.repository.ScheduleRepository;
 import com.songpapeople.hashtagmap.kakao.service.dto.PeriodHistoryDto;
+import com.songpapeople.hashtagmap.scheduler.domain.KakaoScheduler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,6 +18,7 @@ import java.util.List;
 public class KakaoScheduleQueryService {
     private final ScheduleRepository scheduleRepository;
     private final PeriodHistoryRepository historyRepository;
+    private final KakaoScheduler kakaoScheduler;
 
     public boolean getKakaoScheduleActiveStatus(String name) {
         Schedule schedule = scheduleRepository.findByName(name)
@@ -24,6 +26,7 @@ public class KakaoScheduleQueryService {
                         AdminExceptionStatus.NOT_FOUND_SCHEDULER,
                         String.format("%s : 스케쥴러가 존재하지 않습니다.", name)
                 ));
+        kakaoScheduler.syncSchedule(schedule);
         return schedule.isActive();
     }
 

--- a/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleQueryService.java
+++ b/hashtagmap-admin/src/main/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleQueryService.java
@@ -20,13 +20,16 @@ public class KakaoScheduleQueryService {
     private final PeriodHistoryRepository historyRepository;
     private final KakaoScheduler kakaoScheduler;
 
-    public boolean getKakaoScheduleActiveStatus(String name) {
+    public boolean getKakaoScheduleActiveStatus() {
+        return kakaoScheduler.isActive();
+    }
+
+    public boolean getKakaoScheduleAutoRunnable(String name) {
         Schedule schedule = scheduleRepository.findByName(name)
                 .orElseThrow(() -> new AdminException(
                         AdminExceptionStatus.NOT_FOUND_SCHEDULER,
                         String.format("%s : 스케쥴러가 존재하지 않습니다.", name)
                 ));
-        kakaoScheduler.syncSchedule(schedule);
         return schedule.isActive();
     }
 

--- a/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/config/schedule/KakaoScheduleAutoConfigurationTest.java
+++ b/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/config/schedule/KakaoScheduleAutoConfigurationTest.java
@@ -35,8 +35,7 @@ class KakaoScheduleAutoConfigurationTest {
         kakaoScheduleAutoConfiguration.configureKakaoSchedule();
 
         //then
-        boolean result = kakaoScheduler.stop();
-        assertThat(result).isFalse();
+        assertThat(kakaoScheduler.isNotActive()).isTrue();
     }
 
     @DisplayName("Kakao 스케쥴러가 실행되도록 설정")
@@ -56,6 +55,5 @@ class KakaoScheduleAutoConfigurationTest {
     @AfterEach
     void tearDown() {
         scheduleRepository.deleteAll();
-        kakaoScheduler.stop();
     }
 }

--- a/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/docs/kakao/KakaoApiDocumentation.java
+++ b/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/docs/kakao/KakaoApiDocumentation.java
@@ -14,8 +14,8 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 
 public class KakaoApiDocumentation extends ApiDocument {
-    protected RestDocumentationResultHandler getDocumentByToggle() {
-        return document("kakao/scheduler/toggle",
+    protected RestDocumentationResultHandler getDocumentByToggle(String command) {
+        return document("kakao/scheduler/" + command,
                 getDocumentRequest(),
                 getDocumentResponse(),
                 requestFields(

--- a/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/docs/kakao/KakaoApiDocumentation.java
+++ b/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/docs/kakao/KakaoApiDocumentation.java
@@ -14,14 +14,10 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 
 public class KakaoApiDocumentation extends ApiDocument {
-    protected RestDocumentationResultHandler getDocumentByToggle(String command) {
+    protected RestDocumentationResultHandler getDocumentByStartAndStop(String command) {
         return document("kakao/scheduler/" + command,
                 getDocumentRequest(),
-                getDocumentResponse(),
-                requestFields(
-                        fieldWithPath("name").type(JsonFieldType.STRING)
-                                .description("스케줄러의 이름")
-                )
+                getDocumentResponse()
         );
     }
 
@@ -56,6 +52,36 @@ public class KakaoApiDocumentation extends ApiDocument {
                         fieldWithPath("data[0].expression").type(JsonFieldType.STRING).description("변경된 주기 (cron)"),
                         fieldWithPath("data[0].member").type(JsonFieldType.STRING).description("수정한 사람"),
                         fieldWithPath("data[0].changedDate").type(JsonFieldType.STRING).description("수정한 날짜"),
+                        fieldWithPath("code").type(JsonFieldType.NULL).description("에러 코드"),
+                        fieldWithPath("message").type(JsonFieldType.NULL).description("에러 메세지")
+                )
+        );
+    }
+
+    protected RestDocumentationResultHandler getDocumentByChangeAutoRunnable() {
+        return document("kakao/scheduler/auto/toggle",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestFields(
+                        fieldWithPath("name").type(JsonFieldType.STRING).description("카카오 스케쥴 이름")
+                ),
+                responseFields(
+                        fieldWithPath("data").type(JsonFieldType.NULL).description("반환 값"),
+                        fieldWithPath("code").type(JsonFieldType.NULL).description("에러 코드"),
+                        fieldWithPath("message").type(JsonFieldType.NULL).description("에러 메세지")
+                )
+        );
+    }
+
+    protected RestDocumentationResultHandler getDocumentByGetAutoRunnable() {
+        return document("kakao/scheduler/auto/status",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestParameters(
+                        parameterWithName("name").description("카카오 스케쥴 이름")
+                ),
+                responseFields(
+                        fieldWithPath("data").type(JsonFieldType.BOOLEAN).description("자동실행 상태 값"),
                         fieldWithPath("code").type(JsonFieldType.NULL).description("에러 코드"),
                         fieldWithPath("message").type(JsonFieldType.NULL).description("에러 메세지")
                 )

--- a/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/integration/KakaoScheduleIntegrationTest.java
+++ b/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/integration/KakaoScheduleIntegrationTest.java
@@ -5,9 +5,9 @@ import com.songpapeople.hashtagmap.kakao.schedule.model.PeriodHistory;
 import com.songpapeople.hashtagmap.kakao.schedule.model.Schedule;
 import com.songpapeople.hashtagmap.kakao.schedule.repository.PeriodHistoryRepository;
 import com.songpapeople.hashtagmap.kakao.schedule.repository.ScheduleRepository;
-import com.songpapeople.hashtagmap.kakao.service.dto.KakaoScheduleToggleDto;
 import com.songpapeople.hashtagmap.kakao.service.dto.PeriodHistoryDto;
 import com.songpapeople.hashtagmap.response.CustomResponse;
+import com.songpapeople.hashtagmap.scheduler.domain.KakaoScheduler;
 import com.songpapeople.hashtagmap.scheduler.exception.KakaoSchedulerExceptionStatus;
 import io.restassured.RestAssured;
 import io.restassured.mapper.TypeRef;
@@ -38,6 +38,9 @@ class KakaoScheduleIntegrationTest {
     @Autowired
     private ScheduleRepository scheduleRepository;
 
+    @Autowired
+    private KakaoScheduler kakaoScheduler;
+
     protected static RequestSpecification given() {
         return RestAssured.given().log().all();
     }
@@ -49,7 +52,7 @@ class KakaoScheduleIntegrationTest {
 
     @DisplayName("카카오 스케줄러 주기 변경")
     @Test
-    public void changePeriodTest() {
+    void changePeriodTest() {
         String validExpression = "0 0/5 * * * ?";
         CustomResponse<Void> response = changePeriod(validExpression, HttpStatus.OK);
 
@@ -60,7 +63,7 @@ class KakaoScheduleIntegrationTest {
 
     @DisplayName("(예외) 잘못된 주기(정규식)으로 주기 변경 실패")
     @Test
-    public void changePeriodExceptionTest() {
+    void changePeriodExceptionTest() {
         String invalidExpression = "* * * * * * /";
         CustomResponse<Void> response = changePeriod(invalidExpression, HttpStatus.BAD_REQUEST);
 
@@ -73,7 +76,7 @@ class KakaoScheduleIntegrationTest {
 
     @DisplayName("주기 변경 기록 조회")
     @Test
-    public void showPeriodHistoryTest() {
+    void showPeriodHistoryTest() {
         List<PeriodHistory> expected = periodHistoryRepository.saveAll(Arrays.asList(
                 new PeriodHistory("0 0/5 * * * ?"),
                 new PeriodHistory("0 0 * * * ?")
@@ -90,17 +93,11 @@ class KakaoScheduleIntegrationTest {
     @DisplayName("KakaoScheduler 실행 하기")
     @Test
     void toggleSchedulerTest() {
-        //given
-        String scheduleName = "KAKAO";
-        KakaoScheduleToggleDto kakaoScheduleToggleDto = new KakaoScheduleToggleDto(scheduleName);
-        scheduleRepository.save(new Schedule(scheduleName, "", Flag.N));
-
         //when
-        startScheduler(kakaoScheduleToggleDto, HttpStatus.OK);
+        startScheduler(HttpStatus.OK);
 
         //then
-        Schedule schedule = scheduleRepository.findByName(scheduleName).orElseThrow(RuntimeException::new);
-        assertThat(schedule.isActive()).isTrue();
+        assertThat(kakaoScheduler.isActive()).isTrue();
     }
 
     @DisplayName("KakaoScheduler 실행 상태 조회하기")
@@ -117,11 +114,8 @@ class KakaoScheduleIntegrationTest {
         assertThat(response.getData()).isFalse();
     }
 
-    public CustomResponse<Void> startScheduler(KakaoScheduleToggleDto kakaoScheduleToggleDto, HttpStatus expectStatus) {
+    public CustomResponse<Void> startScheduler(HttpStatus expectStatus) {
         return given()
-                .body(kakaoScheduleToggleDto)
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .post("/kakao/scheduler/start")
                 .then()

--- a/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/kakao/api/KakaoApiControllerTest.java
+++ b/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/kakao/api/KakaoApiControllerTest.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = KakaoSchedulerApiController.class)
 public class KakaoApiControllerTest extends KakaoApiDocumentation {
-    private static String SCHEDULER_NAME = "KAKAO";
+    private static final String SCHEDULER_NAME = "KAKAO";
 
     @MockBean
     private KakaoScheduleCommandService kakaoScheduleCommandService;
@@ -35,20 +35,36 @@ public class KakaoApiControllerTest extends KakaoApiDocumentation {
     @MockBean
     private KakaoScheduleQueryService kakaoScheduleQueryService;
 
-    @DisplayName("Kakao Scheduler를 키고 끄는 toggle")
+    @DisplayName("Kakao Scheduler를 실행한다.")
     @Test
-    void toggleTest() throws Exception {
-        doNothing().when(kakaoScheduleCommandService).toggleSchedule(anyString());
+    void startTest() throws Exception {
+        doNothing().when(kakaoScheduleCommandService).startSchedule(anyString());
 
         ObjectMapper objectMapper = new ObjectMapper();
         String requestDto = objectMapper.writeValueAsString(new KakaoScheduleToggleDto(SCHEDULER_NAME));
 
-        mockMvc.perform(post("/kakao/scheduler/toggle")
+        mockMvc.perform(post("/kakao/scheduler/start")
                 .content(requestDto)
                 .header("Content-Type", "application/json"))
                 .andExpect(status().isOk())
-                .andDo(getDocumentByToggle());
+                .andDo(getDocumentByToggle("start"));
     }
+
+    @DisplayName("Kakao Scheduler를 정지한다.")
+    @Test
+    void stopTest() throws Exception {
+        doNothing().when(kakaoScheduleCommandService).stopSchedule(anyString());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String requestDto = objectMapper.writeValueAsString(new KakaoScheduleToggleDto(SCHEDULER_NAME));
+
+        mockMvc.perform(post("/kakao/scheduler/stop")
+                .content(requestDto)
+                .header("Content-Type", "application/json"))
+                .andExpect(status().isOk())
+                .andDo(getDocumentByToggle("stop"));
+    }
+
 
     @DisplayName("Kakao Scheduler 상태 조회")
     @Test

--- a/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/kakao/api/KakaoSchedulerApiControllerExceptionTest.java
+++ b/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/kakao/api/KakaoSchedulerApiControllerExceptionTest.java
@@ -58,16 +58,16 @@ class KakaoSchedulerApiControllerExceptionTest {
                 .build();
     }
 
-    @DisplayName("찾고자 하는 스케쥴러가 없는 경우 Exception")
+    @DisplayName("스케쥴러를 실행할 때 찾고자 하는 스케쥴러가 없는 경우 Exception")
     @Test
     void startCronNotFound() throws Exception {
-        doThrow(new AdminException(AdminExceptionStatus.NOT_FOUND_SCHEDULER, LOG)).when(kakaoScheduleCommandService).toggleSchedule(KAKAO);
+        doThrow(new AdminException(AdminExceptionStatus.NOT_FOUND_SCHEDULER, LOG)).when(kakaoScheduleCommandService).startSchedule(KAKAO);
 
         KakaoScheduleToggleDto kakaoScheduleToggleDto = new KakaoScheduleToggleDto(KAKAO);
         String contents = objectMapper.writeValueAsString(kakaoScheduleToggleDto);
         //given
         MvcResult mvcResult = this.mockMvc.perform(
-                post(BASE_URI + "/toggle")
+                post(BASE_URI + "/start")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(contents)
         )
@@ -88,13 +88,13 @@ class KakaoSchedulerApiControllerExceptionTest {
     @DisplayName("스케쥴러가 이미 실행중일때 Exception")
     @Test
     void startCron() throws Exception {
-        doThrow(new KakaoSchedulerException(KakaoSchedulerExceptionStatus.SCHEDULE_ALREADY_RUNNING, LOG)).when(kakaoScheduleCommandService).toggleSchedule(KAKAO);
+        doThrow(new KakaoSchedulerException(KakaoSchedulerExceptionStatus.SCHEDULE_ALREADY_RUNNING, LOG)).when(kakaoScheduleCommandService).startSchedule(KAKAO);
 
         KakaoScheduleToggleDto kakaoScheduleToggleDto = new KakaoScheduleToggleDto(KAKAO);
         String contents = objectMapper.writeValueAsString(kakaoScheduleToggleDto);
         //given
         MvcResult mvcResult = this.mockMvc.perform(
-                post(BASE_URI + "/toggle")
+                post(BASE_URI + "/start")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(contents)
         )
@@ -112,7 +112,7 @@ class KakaoSchedulerApiControllerExceptionTest {
         assertThat(customResponse.getMessage()).isEqualTo(KakaoSchedulerExceptionStatus.SCHEDULE_ALREADY_RUNNING.getMessage());
     }
 
-    @DisplayName("찾고자 하는 스케쥴러가 없는 경우 Exception")
+    @DisplayName("상태를 알고 싶은 스케쥴러가 없는 경우 Exception")
     @Test
     void getActiveStatusNotFound() throws Exception {
         doThrow(new AdminException(AdminExceptionStatus.NOT_FOUND_SCHEDULER, LOG)).when(kakaoScheduleQueryService).getKakaoScheduleActiveStatus(KAKAO);
@@ -136,14 +136,14 @@ class KakaoSchedulerApiControllerExceptionTest {
         assertThat(customResponse.getMessage()).isEqualTo(AdminExceptionStatus.NOT_FOUND_SCHEDULER.getMessage());
     }
 
-    @DisplayName("전달받은 dto의 값이 비어있는 경우 Exception")
+    @DisplayName("스케쥴러 실행을 위해 전달받은 dto의 값이 비어있는 경우 Exception")
     @Test
     void bindException() throws Exception {
         KakaoScheduleToggleDto kakaoScheduleToggleDto = new KakaoScheduleToggleDto("");
         String contents = objectMapper.writeValueAsString(kakaoScheduleToggleDto);
 
         MvcResult mvcResult = this.mockMvc.perform(
-                post(BASE_URI + "/toggle")
+                post(BASE_URI + "/start")
                         .content(contents)
                         .contentType(MediaType.APPLICATION_JSON)
         )

--- a/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleCommandServiceTest.java
+++ b/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleCommandServiceTest.java
@@ -8,6 +8,8 @@ import com.songpapeople.hashtagmap.scheduler.domain.KakaoScheduler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -32,42 +34,48 @@ class KakaoScheduleCommandServiceTest {
     @Test
     void stopSchedule() {
         //given
-        scheduleRepository.save(new Schedule(KAKAO, "비밥", Flag.Y));
         kakaoScheduler.start();
 
         //when
-        kakaoScheduleCommandService.stopSchedule(KAKAO);
+        kakaoScheduleCommandService.stopSchedule();
 
         //then
-        Schedule schedule = scheduleRepository.findByName(KAKAO).orElseThrow(RuntimeException::new);
-        assertThat(schedule.isActive()).isFalse();
-    }
-
-    @DisplayName("멈출 스케쥴러가 존재하지 않을경우 Exception 발생")
-    @Test
-    void stopScheduleFail() {
-        //given
-        scheduleRepository.save(new Schedule(KAKAO, "비밥", Flag.N));
-
-        //then
-        assertThatThrownBy(() -> kakaoScheduleCommandService.stopSchedule("LINE"))
-                .isInstanceOf(AdminException.class)
-                .hasMessage("스케쥴러(LINE)가 존재하지 않습니다.");
+        assertThat(kakaoScheduler.isActive()).isFalse();
+        assertThat(kakaoScheduler.isNotActive()).isTrue();
     }
 
     @DisplayName("스케쥴러 시작하기 성공")
     @Test
     void startSchedule() {
+        //when
+        kakaoScheduleCommandService.startSchedule();
+
+        //then
+        assertThat(kakaoScheduler.isActive()).isTrue();
+        assertThat(kakaoScheduler.isNotActive()).isFalse();
+        kakaoScheduler.stop();
+    }
+
+    @DisplayName("스케쥴러 자동 실행 상태 변환")
+    @ParameterizedTest
+    @CsvSource(value = {"Y,false", "N,true"})
+    void toggleScheduleAutoRunnable(Flag beforeFlag, boolean expect) {
         //given
-        scheduleRepository.save(new Schedule(KAKAO, "비밥", Flag.N));
+        scheduleRepository.save(new Schedule(KAKAO, "", beforeFlag));
 
         //when
-        kakaoScheduleCommandService.startSchedule(KAKAO);
+        kakaoScheduleCommandService.toggleScheduleAutoRunnable(KAKAO);
 
         //then
         Schedule schedule = scheduleRepository.findByName(KAKAO).orElseThrow(RuntimeException::new);
-        assertThat(schedule.isActive()).isTrue();
-        kakaoScheduler.stop();
+        assertThat(schedule.isActive()).isEqualTo(expect);
+    }
+
+    @Test
+    void toggleScheduleAutoRunnableNotFound() {
+        assertThatThrownBy(() -> kakaoScheduleCommandService.toggleScheduleAutoRunnable(KAKAO))
+                .isInstanceOf(AdminException.class)
+                .hasMessage("스케쥴러(%s)가 존재하지 않습니다.", KAKAO);
     }
 
     @DisplayName("카카오 스케줄러 주기 변경")

--- a/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleCommandServiceTest.java
+++ b/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleCommandServiceTest.java
@@ -33,12 +33,13 @@ class KakaoScheduleCommandServiceTest {
     void stopSchedule() {
         //given
         scheduleRepository.save(new Schedule(KAKAO, "비밥", Flag.Y));
+        kakaoScheduler.start();
 
         //when
-        kakaoScheduleCommandService.toggleSchedule(KAKAO);
+        kakaoScheduleCommandService.stopSchedule(KAKAO);
 
         //then
-        Schedule schedule = scheduleRepository.findByName(KAKAO).get();
+        Schedule schedule = scheduleRepository.findByName(KAKAO).orElseThrow(RuntimeException::new);
         assertThat(schedule.isActive()).isFalse();
     }
 
@@ -49,7 +50,7 @@ class KakaoScheduleCommandServiceTest {
         scheduleRepository.save(new Schedule(KAKAO, "비밥", Flag.N));
 
         //then
-        assertThatThrownBy(() -> kakaoScheduleCommandService.toggleSchedule("LINE"))
+        assertThatThrownBy(() -> kakaoScheduleCommandService.stopSchedule("LINE"))
                 .isInstanceOf(AdminException.class)
                 .hasMessage("스케쥴러(LINE)가 존재하지 않습니다.");
     }
@@ -61,11 +62,12 @@ class KakaoScheduleCommandServiceTest {
         scheduleRepository.save(new Schedule(KAKAO, "비밥", Flag.N));
 
         //when
-        kakaoScheduleCommandService.toggleSchedule(KAKAO);
+        kakaoScheduleCommandService.startSchedule(KAKAO);
 
         //then
-        Schedule schedule = scheduleRepository.findByName(KAKAO).get();
+        Schedule schedule = scheduleRepository.findByName(KAKAO).orElseThrow(RuntimeException::new);
         assertThat(schedule.isActive()).isTrue();
+        kakaoScheduler.stop();
     }
 
     @DisplayName("카카오 스케줄러 주기 변경")
@@ -79,6 +81,5 @@ class KakaoScheduleCommandServiceTest {
     @AfterEach
     void tearDown() {
         scheduleRepository.deleteAll();
-        kakaoScheduler.stop();
     }
 }

--- a/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleQueryServiceTest.java
+++ b/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleQueryServiceTest.java
@@ -15,37 +15,41 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 class KakaoScheduleQueryServiceTest {
-    private static final String KAKAO = "KAKAO";
-    private static final String INSTAGRAM = "INSTAGRAM";
 
+    private static final String KAKAO = "KAKAO";
     @Autowired
     private KakaoScheduleQueryService kakaoScheduleQueryService;
 
     @Autowired
     private ScheduleRepository scheduleRepository;
 
-    @DisplayName("입력한 스케쥴러의 이름으로 스케쥴러의 활성화 상태 조회하기")
+    @DisplayName("카카오 스케쥴러의 활성화 상태 조회하기")
     @Test
     void getKakaoScheduleActiveStatus() {
-        //given
-        scheduleRepository.save(new Schedule(KAKAO, "비밥", Flag.N));
-        scheduleRepository.save(new Schedule(INSTAGRAM, "비밥", Flag.N));
-
         //when
-        boolean kakaoScheduleActiveStatus = kakaoScheduleQueryService.getKakaoScheduleActiveStatus(KAKAO);
+        boolean kakaoScheduleActiveStatus = kakaoScheduleQueryService.getKakaoScheduleActiveStatus();
 
         //then
         assertThat(kakaoScheduleActiveStatus).isFalse();
     }
 
-    @DisplayName("입력한 스케쥴러의 이름에 맞는 스케쥴러가 없는 경우 Exception")
+    @DisplayName("카카오 스케쥴러의 자동실행 가능 상태를 조회한다.")
     @Test
-    void getKakaoScheduleActiveStatusException() {
+    void getKakaoScheduleAutoRunnable() {
         //given
-        scheduleRepository.save(new Schedule(INSTAGRAM, "비밥", Flag.N));
+        scheduleRepository.save(new Schedule(KAKAO, "", Flag.Y));
+
+        //when
+        boolean kakaoAutoRunnable = kakaoScheduleQueryService.getKakaoScheduleAutoRunnable(KAKAO);
 
         //then
-        assertThatThrownBy(() -> kakaoScheduleQueryService.getKakaoScheduleActiveStatus(KAKAO))
+        assertThat(kakaoAutoRunnable).isTrue();
+    }
+
+    @DisplayName("KAKAO 스케쥴러를 찾지 못한 경우")
+    @Test
+    void getKakaoScheduleAutoRunnableNotFound() {
+        assertThatThrownBy(() -> kakaoScheduleQueryService.getKakaoScheduleAutoRunnable(KAKAO))
                 .isInstanceOf(AdminException.class)
                 .hasMessage("%s : 스케쥴러가 존재하지 않습니다.", KAKAO);
     }

--- a/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleQueryServiceTest.java
+++ b/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/kakao/service/KakaoScheduleQueryServiceTest.java
@@ -28,14 +28,14 @@ class KakaoScheduleQueryServiceTest {
     @Test
     void getKakaoScheduleActiveStatus() {
         //given
-        scheduleRepository.save(new Schedule(KAKAO, "비밥", Flag.Y));
+        scheduleRepository.save(new Schedule(KAKAO, "비밥", Flag.N));
         scheduleRepository.save(new Schedule(INSTAGRAM, "비밥", Flag.N));
 
         //when
         boolean kakaoScheduleActiveStatus = kakaoScheduleQueryService.getKakaoScheduleActiveStatus(KAKAO);
 
         //then
-        assertThat(kakaoScheduleActiveStatus).isTrue();
+        assertThat(kakaoScheduleActiveStatus).isFalse();
     }
 
     @DisplayName("입력한 스케쥴러의 이름에 맞는 스케쥴러가 없는 경우 Exception")

--- a/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/taglevel/service/TagLevelCommandServiceTest.java
+++ b/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/taglevel/service/TagLevelCommandServiceTest.java
@@ -30,7 +30,7 @@ class TagLevelCommandServiceTest {
     private InstagramRepository instagramRepository;
 
     @BeforeEach
-    private void setUp() {
+    void setUp() {
         List<Instagram> instagrams = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             instagrams.add(Instagram.builder()
@@ -42,7 +42,7 @@ class TagLevelCommandServiceTest {
 
     @DisplayName("TagLevel 정보를 갱신한다.")
     @Test
-    public void updateTagLevelTest() {
+    void updateTagLevelTest() {
         // given
         List<TagLevel> tagLevels = Arrays.asList(new TagLevel(), new TagLevel());
         tagLevelRepository.saveAll(tagLevels);
@@ -61,7 +61,7 @@ class TagLevelCommandServiceTest {
     }
 
     @AfterEach
-    private void tearDown() {
+    void tearDown() {
         tagLevelRepository.deleteAll();
         instagramRepository.deleteAll();
     }

--- a/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/taglevel/service/TagLevelQueryServiceTest.java
+++ b/hashtagmap-admin/src/test/java/com/songpapeople/hashtagmap/taglevel/service/TagLevelQueryServiceTest.java
@@ -3,6 +3,7 @@ package com.songpapeople.hashtagmap.taglevel.service;
 import com.songpapeople.hashtagmap.taglevel.model.TagLevel;
 import com.songpapeople.hashtagmap.taglevel.repository.TagLevelRepository;
 import com.songpapeople.hashtagmap.taglevel.service.dto.TagLevelDto;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +24,7 @@ class TagLevelQueryServiceTest {
 
     @DisplayName("TagLevel의 정보를 조회한다.")
     @Test
-    public void findAllTest() {
+    void findAllTest() {
         tagLevelRepository.saveAll(Arrays.asList(
                 new TagLevel(1L, 100L, 200L),
                 new TagLevel(2L, 201L, 300L)
@@ -31,5 +32,10 @@ class TagLevelQueryServiceTest {
 
         List<TagLevelDto> tagLevelDtos = tagLevelQueryService.findAll();
         assertThat(tagLevelDtos.size()).isEqualTo(2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        tagLevelRepository.deleteAll();
     }
 }

--- a/hashtagmap-core/src/main/java/com/songpapeople/hashtagmap/kakao/schedule/model/Schedule.java
+++ b/hashtagmap-core/src/main/java/com/songpapeople/hashtagmap/kakao/schedule/model/Schedule.java
@@ -40,4 +40,8 @@ public class Schedule extends BaseEntity {
     public boolean isActive() {
         return this.flag.isYes();
     }
+
+    public boolean isNotActive() {
+        return !this.isActive();
+    }
 }

--- a/hashtagmap-core/src/main/java/com/songpapeople/hashtagmap/kakao/schedule/repository/PeriodHistoryRepository.java
+++ b/hashtagmap-core/src/main/java/com/songpapeople/hashtagmap/kakao/schedule/repository/PeriodHistoryRepository.java
@@ -3,5 +3,8 @@ package com.songpapeople.hashtagmap.kakao.schedule.repository;
 import com.songpapeople.hashtagmap.kakao.schedule.model.PeriodHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PeriodHistoryRepository extends JpaRepository<PeriodHistory, Long> {
+    Optional<PeriodHistory> findTopByOrderByChangedDateDesc();
 }

--- a/hashtagmap-kakao-scheduler/src/main/java/com/songpapeople/hashtagmap/scheduler/domain/KakaoScheduler.java
+++ b/hashtagmap-kakao-scheduler/src/main/java/com/songpapeople/hashtagmap/scheduler/domain/KakaoScheduler.java
@@ -1,6 +1,5 @@
 package com.songpapeople.hashtagmap.scheduler.domain;
 
-import com.songpapeople.hashtagmap.kakao.schedule.model.Schedule;
 import com.songpapeople.hashtagmap.scheduler.exception.KakaoSchedulerException;
 import com.songpapeople.hashtagmap.scheduler.exception.KakaoSchedulerExceptionStatus;
 import lombok.extern.slf4j.Slf4j;
@@ -73,17 +72,6 @@ public class KakaoScheduler {
         this.scheduledFuture.cancel(true);
         log.info("KakaoScheduler stopped at : " + LocalDateTime.now());
         return this.scheduledFuture.isCancelled();
-    }
-
-    public void syncSchedule(Schedule schedule) {
-        if (schedule.isActive() && this.isNotActive()) {
-            log.info("Force Sync Schedule to Stop");
-            schedule.toggle();
-        }
-        if (schedule.isNotActive() && this.isActive()) {
-            log.info("Force Sync Schedule to Start");
-            schedule.toggle();
-        }
     }
 
 }

--- a/hashtagmap-kakao-scheduler/src/main/java/com/songpapeople/hashtagmap/scheduler/exception/KakaoSchedulerExceptionStatus.java
+++ b/hashtagmap-kakao-scheduler/src/main/java/com/songpapeople/hashtagmap/scheduler/exception/KakaoSchedulerExceptionStatus.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum KakaoSchedulerExceptionStatus {
     SCHEDULE_ALREADY_RUNNING("KAKAO_SCHEDULE_1000", "스케쥴러가 이미 실행중입니다."),
-    INVALID_PERIOD_EXPRESSION("KAKAO_SCHEDULER_1001", "기간(정규식)이 잘못되었습니다.");
+    INVALID_PERIOD_EXPRESSION("KAKAO_SCHEDULER_1001", "기간(정규식)이 잘못되었습니다."),
+    SCHEDULE_ALREADY_STOPPED("KAKAO_SCHEDULE_1002", "스케쥴러가 이미 정지되었습니다.");
 
     private final String code;
     private final String message;

--- a/hashtagmap-kakao-scheduler/src/test/java/com/songpapeople/hashtagmap/scheduler/domain/KakaoSchedulerTest.java
+++ b/hashtagmap-kakao-scheduler/src/test/java/com/songpapeople/hashtagmap/scheduler/domain/KakaoSchedulerTest.java
@@ -1,7 +1,5 @@
 package com.songpapeople.hashtagmap.scheduler.domain;
 
-import com.songpapeople.hashtagmap.config.vo.Flag;
-import com.songpapeople.hashtagmap.kakao.schedule.model.Schedule;
 import com.songpapeople.hashtagmap.scheduler.exception.KakaoSchedulerException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -132,35 +130,4 @@ public class KakaoSchedulerTest {
         kakaoScheduler.end();
     }
 
-    @DisplayName("카카오 스케쥴러는 실제로 멈춰있는데 DB에는 실행중이라고 되어있다면 멈춤상태로 변경하기")
-    @Test
-    public void syncSchedulerToStop() {
-        //given
-        KakaoScheduler kakaoScheduler = new KakaoScheduler(() -> {
-        }, new CronPeriod("* * * * * ?"));
-        Schedule schedule = new Schedule("KAKAO", "", Flag.Y);
-
-        //when
-        kakaoScheduler.syncSchedule(schedule);
-
-        //then
-        assertThat(schedule.isActive()).isFalse();
-    }
-
-    @DisplayName("카카오 스케쥴러는 실제로 실행중인데 DB에는 정지라고 되어있다면 시작상태로 변경하기")
-    @Test
-    public void syncSchedulerToStart() {
-        //given
-        KakaoScheduler kakaoScheduler = new KakaoScheduler(() -> {
-        }, new CronPeriod("* * * * * ?"));
-        Schedule schedule = new Schedule("KAKAO", "", Flag.N);
-        kakaoScheduler.start();
-
-        //when
-        kakaoScheduler.syncSchedule(schedule);
-
-        //then
-        assertThat(schedule.isActive()).isTrue();
-        kakaoScheduler.stop();
-    }
 }


### PR DESCRIPTION
refactor : KakaoScheduler 동작방식 변경
 - 애플리케이션이 새롭게 시작될때 가장 최근 period history를 가지고 실행한다.
  - 없으면 기본값으로 실행한다.
 - toggle -> start/stop 방식으로 변경
 - status 확인할때 db와 실제 스케쥴러가 일치하지 않으면 스케쥴러쪽에 db를 동기화
 - instagram이 크롤링 중일때 확인 할 수 있는 방법이 없어서 instagram 크롤링 중 시작을 막는 로직은 추가 못함

closes #168 