### PR TITLE
[FEAT] 에러로그 슬랙으로 관제할 수 있도록 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,5 @@ gradle-app.setting
 /hashtagmap-core/src/main/resources/application-db.yml
 /hashtagmap-admin/src/main/resources/static/**
 /hashtagmap-web/src/main/resources/static/**
+/hashtagmap-web/src/main/resources/application-slack-web-hook.properties
+/hashtagmap-admin/src/main/resources/application-slack-web-hook.properties

--- a/.gitignore
+++ b/.gitignore
@@ -145,5 +145,5 @@ gradle-app.setting
 /hashtagmap-core/src/main/resources/application-db.yml
 /hashtagmap-admin/src/main/resources/static/**
 /hashtagmap-web/src/main/resources/static/**
-/hashtagmap-web/src/main/resources/application-slack-web-hook.properties
-/hashtagmap-admin/src/main/resources/application-slack-web-hook.properties
+/hashtagmap-web/src/main/resources/application-slack-web-hook.yml
+/hashtagmap-admin/src/main/resources/application-slack-web-hook.yml

--- a/build.gradle
+++ b/build.gradle
@@ -92,3 +92,16 @@ configure(asciidoctorConfigure) {
         }
     }
 }
+
+def logbackSlack = [project(':hashtagmap-web'), project(':hashtagmap-admin')]
+configure(logbackSlack) {
+
+    ext {
+        set("logbackSlackAppenderVersion", "1.4.0")
+    }
+
+    dependencies {
+        implementation "com.github.maricn:logback-slack-appender:${logbackSlackAppenderVersion}"
+    }
+
+}

--- a/hashtagmap-admin/build.gradle
+++ b/hashtagmap-admin/build.gradle
@@ -16,6 +16,14 @@ dependencies {
     testImplementation 'io.rest-assured:spring-mock-mvc:3.3.0'
 }
 
+task copyApiKey(type: Copy) {
+    description = "Copy slack web hook uri from hashtagmap-secret"
+    from '../hashtagmap-secret/slack/application-slack-web-hook.properties'
+    into 'src/main/resources/'
+}
+
+processResources.dependsOn 'copyApiKey'
+
 jacocoTestCoverageVerification {
     violationRules {
         rule {

--- a/hashtagmap-admin/build.gradle
+++ b/hashtagmap-admin/build.gradle
@@ -16,13 +16,13 @@ dependencies {
     testImplementation 'io.rest-assured:spring-mock-mvc:3.3.0'
 }
 
-task copyApiKey(type: Copy) {
+task copySlackWebHook(type: Copy) {
     description = "Copy slack web hook uri from hashtagmap-secret"
     from '../hashtagmap-secret/slack/application-slack-web-hook.properties'
     into 'src/main/resources/'
 }
 
-processResources.dependsOn 'copyApiKey'
+processResources.dependsOn 'copySlackWebHook'
 
 jacocoTestCoverageVerification {
     violationRules {

--- a/hashtagmap-admin/build.gradle
+++ b/hashtagmap-admin/build.gradle
@@ -16,13 +16,6 @@ dependencies {
     testImplementation 'io.rest-assured:spring-mock-mvc:3.3.0'
 }
 
-task copySlackWebHook(type: Copy) {
-    description = "Copy slack web hook uri from hashtagmap-secret"
-    from '../hashtagmap-secret/slack/application-slack-web-hook.properties'
-    into 'src/main/resources/'
-}
-
-processResources.dependsOn 'copySlackWebHook'
 
 jacocoTestCoverageVerification {
     violationRules {
@@ -59,8 +52,13 @@ node {
     npmWorkDir = file("./front")
     nodeModulesDir = file("./front")
 }
+task copySlackWebHook(type: Copy) {
+    description = "Copy slack web hook uri from hashtagmap-secret"
+    from '../hashtagmap-secret/slack/application-slack-web-hook.yml'
+    into 'src/main/resources/'
+}
 
-task setUp(type: NpmTask) {
+task setUp(type: NpmTask, dependsOn: copySlackWebHook) {
     description = "Install Node.js Package"
     args = ['install']
 }
@@ -70,4 +68,5 @@ task buildFrontEnd(type: NpmTask, dependsOn: setUp) {
     args = ['run', 'build']
 }
 
+processResources.dependsOn 'copySlackWebHook'
 processResources.dependsOn 'buildFrontEnd'

--- a/hashtagmap-admin/build.gradle
+++ b/hashtagmap-admin/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     testImplementation 'io.rest-assured:spring-mock-mvc:3.3.0'
 }
 
-
 jacocoTestCoverageVerification {
     violationRules {
         rule {
@@ -52,6 +51,7 @@ node {
     npmWorkDir = file("./front")
     nodeModulesDir = file("./front")
 }
+
 task copySlackWebHook(type: Copy) {
     description = "Copy slack web hook uri from hashtagmap-secret"
     from '../hashtagmap-secret/slack/application-slack-web-hook.yml'

--- a/hashtagmap-admin/src/main/resources/logback-spring.xml
+++ b/hashtagmap-admin/src/main/resources/logback-spring.xml
@@ -11,9 +11,10 @@
     <property name="MAX_HISTORY" value="30"/>
     <property name="LOG_PATTERN"
               value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %green([%thread]) %highlight(%-5level) %C.%M:%line :%msg%n"/>
-    <property file="./hashtagmap-admin/src/main/resources/application-slack-web-hook.properties" />
+    <property resource="application-slack-web-hook.yml" />
 
     <springProfile name="!prod">
+
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
                 <pattern>${LOG_PATTERN}</pattern>
@@ -28,7 +29,7 @@
 
     <springProfile name="prod">
         <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
-            <webhookUri>${uri.prod-admin}</webhookUri>
+            <webhookUri>${prod-admin}</webhookUri>
             <channel>#prod-admin</channel>
             <layout class="ch.qos.logback.classic.PatternLayout">
                 <pattern>${LOG_PATTERN}</pattern>

--- a/hashtagmap-admin/src/main/resources/logback-spring.xml
+++ b/hashtagmap-admin/src/main/resources/logback-spring.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-
 <configuration>
     <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
     <property name="LOG_PARENT_PATH" value="../log"/>
@@ -10,7 +9,7 @@
     <property name="LOG_BACKUP" value="../log/backup"/>
     <property name="MAX_HISTORY" value="30"/>
     <property name="LOG_PATTERN"
-              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %green([%thread]) %highlight(%-5level) %C.%M:%line :%msg%n"/>
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) [%C.%M:%line] - %msg%n"/>
     <property resource="application-slack-web-hook.yml" />
 
     <springProfile name="!prod">

--- a/hashtagmap-admin/src/main/resources/logback-spring.xml
+++ b/hashtagmap-admin/src/main/resources/logback-spring.xml
@@ -28,7 +28,7 @@
 
     <springProfile name="prod">
         <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
-            <webhookUri>${slack-web-hook-uri.prod-admin}</webhookUri>
+            <webhookUri>${uri.prod-admin}</webhookUri>
             <channel>#prod-admin</channel>
             <layout class="ch.qos.logback.classic.PatternLayout">
                 <pattern>${LOG_PATTERN}</pattern>

--- a/hashtagmap-admin/src/main/resources/logback-spring.xml
+++ b/hashtagmap-admin/src/main/resources/logback-spring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<configuration>
 
+<configuration>
     <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
     <property name="LOG_PARENT_PATH" value="../log"/>
     <property name="LOG_CHILD_INFO" value="info"/>
@@ -11,12 +11,12 @@
     <property name="MAX_HISTORY" value="30"/>
     <property name="LOG_PATTERN"
               value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %green([%thread]) %highlight(%-5level) %C.%M:%line :%msg%n"/>
+    <property file="./hashtagmap-admin/src/main/resources/application-slack-web-hook.properties" />
 
     <springProfile name="!prod">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <pattern>${LOG_PATTERN}
-                </pattern>
+                <pattern>${LOG_PATTERN}</pattern>
             </encoder>
         </appender>
 
@@ -27,6 +27,24 @@
     </springProfile>
 
     <springProfile name="prod">
+        <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+            <webhookUri>${slack-web-hook-uri.prod-admin}</webhookUri>
+            <channel>#prod-admin</channel>
+            <layout class="ch.qos.logback.classic.PatternLayout">
+                <pattern>${LOG_PATTERN}</pattern>
+            </layout>
+            <username>${HOSTNAME}</username>
+            <iconEmoji>:bright-cow:</iconEmoji>
+            <colorCoding>true</colorCoding>
+        </appender>
+
+        <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="SLACK"/>
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>ERROR</level>
+            </filter>
+        </appender>
+
         <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>${LOG_PARENT_PATH}/${LOG_CHILD_INFO}/info-${BY_DATE}.log</file>
             <filter class="ch.qos.logback.classic.filter.LevelFilter">
@@ -79,6 +97,7 @@
             <appender-ref ref="FILE-INFO"/>
             <appender-ref ref="FILE-WARN"/>
             <appender-ref ref="FILE-ERROR"/>
+            <appender-ref ref="ASYNC_SLACK"/>
         </root>
 
     </springProfile>

--- a/hashtagmap-admin/src/main/resources/logback-spring.xml
+++ b/hashtagmap-admin/src/main/resources/logback-spring.xml
@@ -11,7 +11,7 @@
     <property name="MAX_HISTORY" value="30"/>
     <property name="LOG_PATTERN"
               value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %green([%thread]) %highlight(%-5level) %C.%M:%line :%msg%n"/>
-    <property file="./hashtagmap-admin/src/main/resources/application-slack-web-hook.properties" />
+    <property file="./hashtagmap-web/src/main/resources/application-slack-web-hook.properties" />
 
     <springProfile name="!prod">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">

--- a/hashtagmap-admin/src/main/resources/logback-spring.xml
+++ b/hashtagmap-admin/src/main/resources/logback-spring.xml
@@ -11,7 +11,7 @@
     <property name="MAX_HISTORY" value="30"/>
     <property name="LOG_PATTERN"
               value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %green([%thread]) %highlight(%-5level) %C.%M:%line :%msg%n"/>
-    <property file="./hashtagmap-web/src/main/resources/application-slack-web-hook.properties" />
+    <property file="./hashtagmap-admin/src/main/resources/application-slack-web-hook.properties" />
 
     <springProfile name="!prod">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">

--- a/hashtagmap-web/build.gradle
+++ b/hashtagmap-web/build.gradle
@@ -58,7 +58,7 @@ task copySlackWebHook(type: Copy) {
     into 'src/main/resources/'
 }
 
-processResources.dependsOn 'copyKaKaoApiKey'
+processResources.dependsOn 'copyKakaoApiKey'
 processResources.dependsOn 'copySlackWebHook'
 
 task setUp(type: NpmTask) {

--- a/hashtagmap-web/build.gradle
+++ b/hashtagmap-web/build.gradle
@@ -46,22 +46,19 @@ node {
     nodeModulesDir = file("./front")
 }
 
-task copyKakaoApiKey(type: Copy) {
+task copySlackWebHook(type: Copy) {
+    description = "Copy slack web hook uri from hashtagmap-secret"
+    from '../hashtagmap-secret/slack/application-slack-web-hook.yml'
+    into 'src/main/resources/'
+}
+
+task copyKakaoApiKey(type: Copy, dependsOn: copySlackWebHook) {
     description = "Copy kakao map api key from hashtagmap-secret"
     from '../hashtagmap-secret/kakao/index.js'
     into 'front/src/secret/'
 }
 
-task copySlackWebHook(type: Copy) {
-    description = "Copy slack web hook uri from hashtagmap-secret"
-    from '../hashtagmap-secret/slack/application-slack-web-hook.properties'
-    into 'src/main/resources/'
-}
-
-processResources.dependsOn 'copyKakaoApiKey'
-processResources.dependsOn 'copySlackWebHook'
-
-task setUp(type: NpmTask) {
+task setUp(type: NpmTask, dependsOn: copyKakaoApiKey) {
     description = "Install Node.js Package"
     args = ['install']
 }
@@ -70,4 +67,7 @@ task buildFrontEnd(type: NpmTask, dependsOn: setUp) {
     description = "Build vue.js"
     args = ['run', 'build']
 }
+
+processResources.dependsOn 'copyKakaoApiKey'
+processResources.dependsOn 'copySlackWebHook'
 processResources.dependsOn 'buildFrontEnd'

--- a/hashtagmap-web/build.gradle
+++ b/hashtagmap-web/build.gradle
@@ -50,7 +50,12 @@ task copyApiKey(type: Copy) {
     description = "Copy kakao map api key from hashtagmap-secret"
     from '../hashtagmap-secret/kakao/index.js'
     into 'front/src/secret/'
+    description = "Copy slack web hook uri from hashtagmap-secret"
+    from '../hashtagmap-secret/slack/application-slack-web-hook.properties'
+    into 'src/main/resources/'
 }
+
+processResources.dependsOn 'copyApiKey'
 
 task setUp(type: NpmTask, dependsOn: copyApiKey) {
     description = "Install Node.js Package"

--- a/hashtagmap-web/build.gradle
+++ b/hashtagmap-web/build.gradle
@@ -46,18 +46,22 @@ node {
     nodeModulesDir = file("./front")
 }
 
-task copyApiKey(type: Copy) {
+task copyKakaoApiKey(type: Copy) {
     description = "Copy kakao map api key from hashtagmap-secret"
     from '../hashtagmap-secret/kakao/index.js'
     into 'front/src/secret/'
+}
+
+task copySlackWebHook(type: Copy) {
     description = "Copy slack web hook uri from hashtagmap-secret"
     from '../hashtagmap-secret/slack/application-slack-web-hook.properties'
     into 'src/main/resources/'
 }
 
-processResources.dependsOn 'copyApiKey'
+processResources.dependsOn 'copyKaKaoApiKey'
+processResources.dependsOn 'copySlackWebHook'
 
-task setUp(type: NpmTask, dependsOn: copyApiKey) {
+task setUp(type: NpmTask) {
     description = "Install Node.js Package"
     args = ['install']
 }
@@ -66,5 +70,4 @@ task buildFrontEnd(type: NpmTask, dependsOn: setUp) {
     description = "Build vue.js"
     args = ['run', 'build']
 }
-
 processResources.dependsOn 'buildFrontEnd'

--- a/hashtagmap-web/src/main/resources/logback-spring.xml
+++ b/hashtagmap-web/src/main/resources/logback-spring.xml
@@ -28,7 +28,7 @@
 
     <springProfile name="prod">
         <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
-            <webhookUri>${slack-web-hook-uri.prod-web}</webhookUri>
+            <webhookUri>${uri.prod-web}</webhookUri>
             <channel>#prod-web</channel>
             <layout class="ch.qos.logback.classic.PatternLayout">
                 <pattern>${LOG_PATTERN}</pattern>

--- a/hashtagmap-web/src/main/resources/logback-spring.xml
+++ b/hashtagmap-web/src/main/resources/logback-spring.xml
@@ -10,10 +10,11 @@
     <property name="LOG_BACKUP" value="../log/backup"/>
     <property name="MAX_HISTORY" value="30"/>
     <property name="LOG_PATTERN"
-              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %green([%thread]) %highlight(%-5level) %C.%M:%line :%msg%n"/>
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) [%C.%M:%line] - %msg%n"/>
     <property resource="application-slack-web-hook.yml" />
 
     <springProfile name="!prod">
+
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
                 <pattern>${LOG_PATTERN}</pattern>

--- a/hashtagmap-web/src/main/resources/logback-spring.xml
+++ b/hashtagmap-web/src/main/resources/logback-spring.xml
@@ -11,7 +11,7 @@
     <property name="MAX_HISTORY" value="30"/>
     <property name="LOG_PATTERN"
               value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %green([%thread]) %highlight(%-5level) %C.%M:%line :%msg%n"/>
-    <property file="./hashtagmap-web/src/main/resources/application-slack-web-hook.properties" />
+    <property resource="application-slack-web-hook.yml" />
 
     <springProfile name="!prod">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -28,7 +28,7 @@
 
     <springProfile name="prod">
         <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
-            <webhookUri>${uri.prod-web}</webhookUri>
+            <webhookUri>${prod-web}</webhookUri>
             <channel>#prod-web</channel>
             <layout class="ch.qos.logback.classic.PatternLayout">
                 <pattern>${LOG_PATTERN}</pattern>

--- a/hashtagmap-web/src/main/resources/logback-spring.xml
+++ b/hashtagmap-web/src/main/resources/logback-spring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<configuration>
 
+<configuration>
     <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
     <property name="LOG_PARENT_PATH" value="../log"/>
     <property name="LOG_CHILD_INFO" value="info"/>
@@ -10,13 +10,13 @@
     <property name="LOG_BACKUP" value="../log/backup"/>
     <property name="MAX_HISTORY" value="30"/>
     <property name="LOG_PATTERN"
-              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %green([%thread]) %highlight(%-5level) %C.%M :%msg%n"/>
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %green([%thread]) %highlight(%-5level) %C.%M:%line :%msg%n"/>
+    <property file="./hashtagmap-admin/src/main/resources/application-slack-web-hook.properties" />
 
     <springProfile name="!prod">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <pattern>${LOG_PATTERN}
-                </pattern>
+                <pattern>${LOG_PATTERN}</pattern>
             </encoder>
         </appender>
 
@@ -27,6 +27,24 @@
     </springProfile>
 
     <springProfile name="prod">
+        <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+            <webhookUri>${slack-web-hook-uri.prod-web}</webhookUri>
+            <channel>#prod-web</channel>
+            <layout class="ch.qos.logback.classic.PatternLayout">
+                <pattern>${LOG_PATTERN}</pattern>
+            </layout>
+            <username>${HOSTNAME}</username>
+            <iconEmoji>:bright-cow:</iconEmoji>
+            <colorCoding>true</colorCoding>
+        </appender>
+
+        <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="SLACK"/>
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>ERROR</level>
+            </filter>
+        </appender>
+
         <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>${LOG_PARENT_PATH}/${LOG_CHILD_INFO}/info-${BY_DATE}.log</file>
             <filter class="ch.qos.logback.classic.filter.LevelFilter">
@@ -79,6 +97,7 @@
             <appender-ref ref="FILE-INFO"/>
             <appender-ref ref="FILE-WARN"/>
             <appender-ref ref="FILE-ERROR"/>
+            <appender-ref ref="ASYNC_SLACK"/>
         </root>
 
     </springProfile>

--- a/hashtagmap-web/src/main/resources/logback-spring.xml
+++ b/hashtagmap-web/src/main/resources/logback-spring.xml
@@ -11,7 +11,7 @@
     <property name="MAX_HISTORY" value="30"/>
     <property name="LOG_PATTERN"
               value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %green([%thread]) %highlight(%-5level) %C.%M:%line :%msg%n"/>
-    <property file="./hashtagmap-admin/src/main/resources/application-slack-web-hook.properties" />
+    <property file="./hashtagmap-web/src/main/resources/application-slack-web-hook.properties" />
 
     <springProfile name="!prod">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
admin과 web 모듈의 error 레벨의 log를 슬랙메세지로 보냅니다. (슬랙 채널 #prod-admin, #prod-web)
시크릿 모듈에 slack폴더를 추가해 슬랙 채널의 admin채널과 web채널의 web hook uri를 관리합니다.

admin채널과 web채널의 web hook uri 가 달라서 admin, web 모듈별로 logback.xml은 따로 가지고있어야 할 것 같긴해요.
PR로 의견남겨주시고 반영 후에 문서화도 할 예정입니다!

빌드가 안됐던 것은 라빈 말대로 build할때 setup전에 secret 모듈의 slack 관련 파일을 복사해와야 하는데 제가 그걸 안했었네요 ㅠ
그래서 파일을 못찾는다는 오류가 났던 걸로 추정돼요.

slack설정은 별 거 없는데 외부 property를 logback.xml에서 읽어오는 데 삽질을 많이해서 오래걸렸습니다 ㅠ

테스트로 보냈던 슬랙은 logback.xml에서 !prod환경에 똑같이 설정을 해주고 직접 요청을 보내서 log.error를 찍었습니다. 그래서 슬랙에 갔던 내용이 알아보기 힘들게 뜬 걸로 추정돼요. 아마 실제 환경에서는 현재 ec2에서 보는 에러로그랑 똑같이 슬랙에 메세지가 올겁니다.

fixes #171 