### PR TITLE
[FEAT] 정적 리소스 캐싱

### DIFF
--- a/hashtagmap-web/src/main/java/com/songpapeople/hashtagmap/config/StaticResourcePath.java
+++ b/hashtagmap-web/src/main/java/com/songpapeople/hashtagmap/config/StaticResourcePath.java
@@ -1,0 +1,17 @@
+package com.songpapeople.hashtagmap.config;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public enum StaticResourcePath {
+    JS("/js/**", "js"),
+    CSS("/css/**", "css"),
+    IMG("/img/**", "img");
+
+    private final String path;
+    private final String directory;
+
+}

--- a/hashtagmap-web/src/main/java/com/songpapeople/hashtagmap/config/WebMvcConfiguration.java
+++ b/hashtagmap-web/src/main/java/com/songpapeople/hashtagmap/config/WebMvcConfiguration.java
@@ -16,17 +16,11 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        ResourceHandlerRegistration jsResourceHandler = registry.addResourceHandler("/js/**");
-        ResourceHandlerRegistration cssResourceHandler = registry.addResourceHandler("/css/**");
-        ResourceHandlerRegistration imgResourceHandler = registry.addResourceHandler("/img/**");
-        setCacheController(jsResourceHandler, "js");
-        setCacheController(cssResourceHandler, "css");
-        setCacheController(imgResourceHandler, "img");
-    }
-
-    private void setCacheController(ResourceHandlerRegistration resourceHandlerRegistration, String directory) {
-        resourceHandlerRegistration.addResourceLocations("classpath:/static/" + directory + "/")
-                .setCacheControl(CacheControl.maxAge(60 * 60 * 24 * 365, TimeUnit.SECONDS).cachePublic());
+        for (StaticResourcePath path : StaticResourcePath.values()) {
+            ResourceHandlerRegistration resourceHandlerRegistration = registry.addResourceHandler(path.getPath());
+            resourceHandlerRegistration.addResourceLocations("classpath:/static/" + path.getDirectory() + "/")
+                    .setCacheControl(CacheControl.maxAge(60 * 60 * 24 * 365, TimeUnit.SECONDS).cachePublic());
+        }
     }
 
     @Bean

--- a/hashtagmap-web/src/main/java/com/songpapeople/hashtagmap/config/WebMvcConfiguration.java
+++ b/hashtagmap-web/src/main/java/com/songpapeople/hashtagmap/config/WebMvcConfiguration.java
@@ -1,0 +1,33 @@
+package com.songpapeople.hashtagmap.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import javax.servlet.Filter;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class WebMvcConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/**")
+                .addResourceLocations("classpath:/static/")
+                .setCacheControl(CacheControl.maxAge(60 * 60 * 24 * 365, TimeUnit.SECONDS).cachePublic());
+    }
+
+
+    @Bean
+    public FilterRegistrationBean filterRegistrationBean() {
+        FilterRegistrationBean registration = new FilterRegistrationBean();
+        Filter etagHeaderFilter = new ShallowEtagHeaderFilter();
+        registration.setFilter(etagHeaderFilter);
+        registration.addUrlPatterns("/**");
+        return registration;
+    }
+}

--- a/hashtagmap-web/src/main/java/com/songpapeople/hashtagmap/config/WebMvcConfiguration.java
+++ b/hashtagmap-web/src/main/java/com/songpapeople/hashtagmap/config/WebMvcConfiguration.java
@@ -5,10 +5,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.CacheControl;
 import org.springframework.web.filter.ShallowEtagHeaderFilter;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import javax.servlet.Filter;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
@@ -16,18 +16,24 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("/**")
-                .addResourceLocations("classpath:/static/")
+        ResourceHandlerRegistration jsResourceHandler = registry.addResourceHandler("/js/**");
+        ResourceHandlerRegistration cssResourceHandler = registry.addResourceHandler("/css/**");
+        ResourceHandlerRegistration imgResourceHandler = registry.addResourceHandler("/img/**");
+        setCacheController(jsResourceHandler, "js");
+        setCacheController(cssResourceHandler, "css");
+        setCacheController(imgResourceHandler, "img");
+    }
+
+    private void setCacheController(ResourceHandlerRegistration resourceHandlerRegistration, String directory) {
+        resourceHandlerRegistration.addResourceLocations("classpath:/static/" + directory + "/")
                 .setCacheControl(CacheControl.maxAge(60 * 60 * 24 * 365, TimeUnit.SECONDS).cachePublic());
     }
 
-
     @Bean
-    public FilterRegistrationBean filterRegistrationBean() {
-        FilterRegistrationBean registration = new FilterRegistrationBean();
-        Filter etagHeaderFilter = new ShallowEtagHeaderFilter();
-        registration.setFilter(etagHeaderFilter);
-        registration.addUrlPatterns("/**");
-        return registration;
+    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
+        FilterRegistrationBean<ShallowEtagHeaderFilter> filterRegistrationBean = new FilterRegistrationBean<>(
+                new ShallowEtagHeaderFilter());
+        filterRegistrationBean.addUrlPatterns("/js/*", "/css/*", "/img/*");
+        return filterRegistrationBean;
     }
 }

--- a/hashtagmap-web/src/main/resources/application.yml
+++ b/hashtagmap-web/src/main/resources/application.yml
@@ -5,8 +5,18 @@ spring:
   profiles:
     include: >
       db
+  resources:
+    chain:
+      strategy:
+        content:
+          enabled: true
 server:
   port: 9000
+  compression:
+    enabled: true
+    mime-types: text/html, text/css, text/javascript, application/javascript, application/json, image/png
+    min-response-size: 2048
+
 ---
 spring.profiles: set1
 

--- a/hashtagmap-web/src/test/java/com/songpapeople/hashtagmap/web/StaticResourceTest.java
+++ b/hashtagmap-web/src/test/java/com/songpapeople/hashtagmap/web/StaticResourceTest.java
@@ -1,0 +1,52 @@
+package com.songpapeople.hashtagmap.web;
+
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class StaticResourceTest {
+    @LocalServerPort
+    private int port;
+
+    private static RequestSpecification given() {
+        return RestAssured.given().log().all();
+    }
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @DisplayName("리소스 파일 캐싱 테스트")
+    @Test
+    void cacheResource() {
+        given()
+                .accept(MediaType.TEXT_HTML_VALUE)
+                .when()
+                .get("/index.html")
+                .then()
+                .log().all()
+                .statusCode(HttpStatus.OK.value())
+                .assertThat().header("Cache-Control", "max-age=31536000, public");
+    }
+
+    @DisplayName("리소스 파일 압축 테스트")
+    @Test
+    void gzipResource() {
+        given()
+                .accept(MediaType.TEXT_HTML_VALUE)
+                .when()
+                .get("/index.html")
+                .then()
+                .log().all()
+                .statusCode(HttpStatus.OK.value())
+                .assertThat().header("Content-Encoding", "gzip");
+    }
+}

--- a/hashtagmap-web/src/test/java/com/songpapeople/hashtagmap/web/StaticResourceTest.java
+++ b/hashtagmap-web/src/test/java/com/songpapeople/hashtagmap/web/StaticResourceTest.java
@@ -1,6 +1,7 @@
 package com.songpapeople.hashtagmap.web;
 
 import io.restassured.RestAssured;
+import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -9,6 +10,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class StaticResourceTest {
@@ -28,10 +31,11 @@ public class StaticResourceTest {
     @Test
     void cacheResource() {
         given()
-                .accept(MediaType.TEXT_HTML_VALUE)
                 .when()
-                .get("/index.html")
+                .accept("image/png")
+                .get("/img/icons/menu-bar-icon.png")
                 .then()
+                .contentType("image/png")
                 .log().all()
                 .statusCode(HttpStatus.OK.value())
                 .assertThat().header("Cache-Control", "max-age=31536000, public");
@@ -46,7 +50,39 @@ public class StaticResourceTest {
                 .get("/index.html")
                 .then()
                 .log().all()
+                .contentType("text/html")
                 .statusCode(HttpStatus.OK.value())
                 .assertThat().header("Content-Encoding", "gzip");
+    }
+
+    @DisplayName("리소스 응답 Etag 반환 테스트")
+    @Test
+    void etagResource() {
+        Response response = given()
+                .accept("image/png")
+                .when()
+                .get("/img/icons/menu-bar-icon.png");
+
+        String etagValue = response.getHeader("Etag");
+
+        assertThat(etagValue).isNotNull();
+    }
+
+    @DisplayName("리소스 두 번째 요청 304응답 테스트")
+    @Test
+    void etagRedirectResource() {
+        Response response = given()
+                .accept("image/png")
+                .when()
+                .get("/img/icons/menu-bar-icon.png");
+        String etagValue = response.getHeader("Etag");
+
+        given()
+                .header("If-None-Match", etagValue)
+                .when()
+                .get("/img/icons/menu-bar-icon.png")
+                .then()
+                .log().all()
+                .statusCode(HttpStatus.NOT_MODIFIED.value());
     }
 }


### PR DESCRIPTION
테크코스 강의 페이지 1단계 하는 쪽에 HTTP 학습에 따른 활용보면 관련 내용이 다 있씁니다.
이미지 최적화쪽은 대부분 kakao에서 받아오는 이미지고 저희 서비스 이미지요청이 얼마 없어서 안했써요.  
- 모든 js, css, images 파일의 캐싱 주기를 1년으로 설정한다. 가 프로젝트 요구사항이라 그렇게 적용했음 
- 모든 js, css, images 파일에 Etag 적용
- html, css, js, json, png 파일에  GZIP을 사용한 텍스트 압축 적용
- 스프링부트에서 제공하는 버전관리를 적용하긴 했는데 어차피 vue에서 빌드할 때 파일에 버전이 지정돼서 빌드됨. img/icons 의 파일들 제외
- pwa를 사용하려고? 만들었던? ServiceWorker가 캐싱을 해줘서 서버 캐싱적용이 의미가 있나..싶음, 요청 자체가 서버로 전달이 안되는걸 라빈이 nginx 로그를 통해 확인했음
- 그래서 nginx 캐싱도 적용할 필요가 있나 싶음.,

fixes: #229 