### PR TITLE
[DOCS] hashtagmap-web, hashtagmap-instagram-crawler 모듈의 README.md 작성

### DIFF
--- a/hashtagmap-instagram-crawler/README.md
+++ b/hashtagmap-instagram-crawler/README.md
@@ -1,6 +1,12 @@
 # Instagram Crawler
 
-## 사용 기술
+## 모듈 설명
+
+- 인스타그램에서 가게 검색 데이터를 크롤링하는 기능을 제공하는 모듈.
+- 크롤링 기능을 외부 라이브러리로 제공할 수 있다.
+- hashtagmap-common 모듈을 이용해 커스텀 예외 객체를 사용한다.
+
+## 기술 스택
 
 - Jsoup
 
@@ -19,11 +25,8 @@ public static Document crawling(String url) {
 }
 ```
 
-
-
-## 사용방법
-
-### InstagramCrawler.createHashtagDto(검색할 이름)
+**사용방법**
+```InstagramCrawler.createHashtagDto(검색할 이름)```
 
 ```java
 public CrawlingDto createHashtagDto(String placeName) {
@@ -34,11 +37,11 @@ public CrawlingDto createHashtagDto(String placeName) {
 }
 ```
 
-
-
-CrawlingDto에 포함된 정보
-
+**CrawlingDto에 포함된 정보**
 - 가게이름
 - 해시태크 게시물 수
 - 인기게시물 9개의 postUrl 과 imageUrl
 
+- 코드 품질 검증
+    - JaCoCo를 이용해 테스트 코드의 커버리지 검증
+    - SonarQube를 이용해 서비스 코드 정적 분석

--- a/hashtagmap-instagram-crawler/README.md
+++ b/hashtagmap-instagram-crawler/README.md
@@ -2,7 +2,7 @@
 
 ## 모듈 설명
 
-- 인스타그램에서 가게 검색 데이터를 크롤링하는 기능을 제공하는 모듈.
+- 인스타그램에서 가게 이름에 대한 해시태그 수, 이미지 등을 크롤링하는 기능을 제공하는 모듈.
 - 크롤링 기능을 외부 라이브러리로 제공할 수 있다.
 - hashtagmap-common 모듈을 이용해 커스텀 예외 객체를 사용한다.
 
@@ -41,7 +41,3 @@ public CrawlingDto createHashtagDto(String placeName) {
 - 가게이름
 - 해시태크 게시물 수
 - 인기게시물 9개의 postUrl 과 imageUrl
-
-- 코드 품질 검증
-    - JaCoCo를 이용해 테스트 코드의 커버리지 검증
-    - SonarQube를 이용해 서비스 코드 정적 분석

--- a/hashtagmap-web/README.md
+++ b/hashtagmap-web/README.md
@@ -10,9 +10,6 @@
 
 - Vue.js
     - PWA를 이용해 모바일에서도 서비스 활용성 증가
-- 무중단 배포
-    - nginx를 활용해 무중단 배포로 운영 중
-    - Spring actuator를 활용해 어플리케이션의 상태를 관제 중
 - spring-boot-starter-web
     - spring-webmvc 프레임워크를 활용해 Model-View-Controller 구조 설계
 - Spring REST Docs를 활용한 api 문서화

--- a/hashtagmap-web/README.md
+++ b/hashtagmap-web/README.md
@@ -1,0 +1,24 @@
+# Web
+
+## 모듈 설명
+
+- 서비스를 제공하는 모듈.
+- hashtagmap-core 모듈을 사용하여 서비스에 제공하는 데이터를 받아온다.
+- hashtagmap-common 모듈에서 api 응답 객체를 사용한다.
+
+## 기술 스택
+
+- Vue.js
+    - PWA를 이용해 모바일에서도 서비스 활용성 증가
+- 무중단 배포
+    - nginx를 활용해 무중단 배포로 운영 중
+    - Spring actuator를 활용해 어플리케이션의 상태를 관제 중
+- spring-boot-starter-web
+    - spring-webmvc 프레임워크를 활용해 Model-View-Controller 구조 설계
+- Spring REST Docs를 활용한 api 문서화
+- JUnit5
+    - MockMvc를 활용한 Controller Layer 테스트 작성
+    - REST-assured를 활용한 End-to-End 테스트 작성
+- 코드 품질 검증
+    - JaCoCo를 이용해 테스트 코드의 커버리지 검증
+    - SonarQube를 이용해 서비스 코드 정적 분석

--- a/hashtagmap-web/README.md
+++ b/hashtagmap-web/README.md
@@ -2,8 +2,8 @@
 
 ## 모듈 설명
 
-- 서비스를 제공하는 모듈.
-- hashtagmap-core 모듈을 사용하여 서비스에 제공하는 데이터를 받아온다.
+- 사용자를 위한 기능을 제공하는 어플리케이션 모듈.
+- hashtagmap-core 모듈을 사용하여 데이터를 조회한다.
 - hashtagmap-common 모듈에서 api 응답 객체를 사용한다.
 
 ## 기술 스택
@@ -17,8 +17,5 @@
     - spring-webmvc 프레임워크를 활용해 Model-View-Controller 구조 설계
 - Spring REST Docs를 활용한 api 문서화
 - JUnit5
-    - MockMvc를 활용한 Controller Layer 테스트 작성
-    - REST-assured를 활용한 End-to-End 테스트 작성
-- 코드 품질 검증
-    - JaCoCo를 이용해 테스트 코드의 커버리지 검증
-    - SonarQube를 이용해 서비스 코드 정적 분석
+- MockMvc를 활용한 Controller Layer 테스트 작성
+- REST-assured를 활용한 End-to-End 테스트 작성


### PR DESCRIPTION
DOCS 이슈 템플릿이 없는데 임의로 DOCS로 제목만 바꿔서 만들었습니다!

rest docs, jacoco, sonarqube는 전체적으로 적용된 부분인데 일단 web 모듈의 readme.md에 작성해놨습니다.
이거를 중복으로 모듈마다 기술할지 하나로 몰아넣을지 한번 이야기 나눠보면 좋겠네요 :)
혹시 누락된 부분에 대해서 리뷰 부탁드릴께요!

closed: #254 