### PR TITLE
[REFACTOR] instagram-post image_url 데이터 포맷 변경

### DIFF
--- a/hashtagmap-core/src/main/java/com/songpapeople/hashtagmap/instagram/domain/model/InstagramPost.java
+++ b/hashtagmap-core/src/main/java/com/songpapeople/hashtagmap/instagram/domain/model/InstagramPost.java
@@ -16,8 +16,10 @@ import javax.persistence.Entity;
 @Entity
 public class InstagramPost extends BaseEntity {
     private Long instagramId;
-    private String imageUrl;
     private String postUrl;
+
+    @Column(columnDefinition = "TEXT")
+    private String imageUrl;
 
     @Builder
     public InstagramPost(Long id, Long instagramId, String imageUrl, String postUrl) {


### PR DESCRIPTION
PR 내용: 
- 기존에 데이터베이스에 저장하는 자료형이 varchar(255) 였는데 길이가 짧아서 저장이 안되서 TEXT로 타입을 변경했습니다.
- 지금은 hashtagmap_dev 데이터베이스에만 해당 변경 사항이 적용되어있습니다.
- approve되면 머지 후에 운영환경에도 적용해놓겠습니다.
- 데이터 직접 띄워보시려면 feature/2020-songpa-people-267 브랜치에서 profiles.active=dev 로 놓고 실행해봐야 합니다!

특이 사항 및 트러블 슈팅: 

프로젝트 외부 설정: 

closed: #267 